### PR TITLE
feat(dashboard-per-role): render dashboards dynamically based on user role from WhoAmI

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -52,7 +52,6 @@ export default {
 			eas: {
 				projectId: '9082188e-00ad-4870-a784-a22d7a9af57a',
 			},
-			// 👇 Esta línea inyecta la variable del .env
 			EXPO_PUBLIC_API_URL: process.env.EXPO_PUBLIC_API_URL,
 		},
 		owner: 'mrwisz',

--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -1,5 +1,3 @@
-// app/(auth)/_layout.tsx
-
 import { Stack } from 'expo-router';
 
 export default function AuthLayout() {
@@ -9,8 +7,6 @@ export default function AuthLayout() {
 			<Stack.Screen name='register' options={{ headerShown: false }} />
 			<Stack.Screen name='forgot-password' options={{ headerShown: false }} />
 			<Stack.Screen name='confirm-email' options={{ headerShown: false }} />
-
-			{/* Puedes agregar más pantallas aquí a medida que las crees */}
 		</Stack>
 	);
 }

--- a/app/(auth)/confirm-email.tsx
+++ b/app/(auth)/confirm-email.tsx
@@ -59,7 +59,7 @@ export default function ConfirmEmailScreen() {
 				const token = loginResponse.token || null;
 
 				if (!token) {
-					console.error('❌ No se recibió token después del login automático');
+					console.error('No se recibió token después del login automático');
 					showToast(
 						'error',
 						'Error',
@@ -81,7 +81,7 @@ export default function ConfirmEmailScreen() {
 				} else if (loginErr instanceof Error) {
 					errorMessage = loginErr.message;
 				}
-				console.error('❌ Error en login automático:', loginErr);
+				console.error('Error en login automático:', loginErr);
 				showToast('error', 'Error', errorMessage);
 				setTimeout(() => router.replace('/(auth)/login'), 2000);
 			}
@@ -93,7 +93,7 @@ export default function ConfirmEmailScreen() {
 			} else if (error instanceof Error) {
 				errorMessage = error.message;
 			}
-			console.error('❌ Error al confirmar o iniciar sesión:', error);
+			console.error('Error al confirmar o iniciar sesión:', error);
 			showToast('error', 'Error', errorMessage);
 		} finally {
 			setIsLoading(false);
@@ -128,12 +128,11 @@ export default function ConfirmEmailScreen() {
 					message={toastState.message}
 					onClose={hideToast}
 				/>
-				{/* Logo */}
+
 				<View className='items-center mb-8'>
 					<Logo />
 				</View>
 
-				{/* Title */}
 				<View className='mb-16'>
 					<ThemedText
 						type='title'
@@ -159,12 +158,10 @@ export default function ConfirmEmailScreen() {
 					</ThemedText>
 				</View>
 
-				{/* Message */}
 				<Text className='text-gray-500 text-center mb-8 text-lg'>
 					Te hemos enviado un código a tu correo electrónico.
 				</Text>
 
-				{/* Code Input */}
 				<View className='w-full max-w-xs mb-8'>
 					<Text className='text-sm text-gray-500 mb-1 font-semibold'></Text>
 					<CodeInput
@@ -174,14 +171,12 @@ export default function ConfirmEmailScreen() {
 					/>
 				</View>
 
-				{/* Resend Code Link */}
 				<TouchableOpacity onPress={handleResendCode} className='mb-8'>
 					<Text className='text-blue-500 font-semibold'>
 						¿No recibiste el código? Reenviar
 					</Text>
 				</TouchableOpacity>
 
-				{/* Buttons */}
 				<View className='w-full gap-4'>
 					<PrimaryButton
 						title={isLoading ? 'Verificando...' : 'Continuar'}

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,5 +1,12 @@
-// app/(auth)/login.tsx
+import { LogoSimple } from '@/components/auth/Logo';
+import { SocialButton } from '@/components/auth/SocialButton';
+import { PrimaryButton } from '@/components/PrimaryButton';
+import { ToastNotification } from '@/components/ToastNotification';
+import { Colors, Fonts } from '@/constants/theme';
+import { useToast } from '@/hooks/useToast';
+import vitalFitApi from '@/services/vitalfitSdk';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { isAPIError } from '@vitalfit/sdk';
 import Checkbox from 'expo-checkbox';
 import { Link, useRouter } from 'expo-router';
 import { Eye, EyeOff, SlidersVertical } from 'lucide-react-native';
@@ -13,19 +20,7 @@ import {
 	TouchableOpacity,
 	TouchableWithoutFeedback,
 	View,
-} from 'react-native'; // <ScrollView> removed
-
-// Componentes personalizados
-import { LogoSimple } from '@/components/auth/Logo';
-import { SocialButton } from '@/components/auth/SocialButton';
-import { PrimaryButton } from '@/components/PrimaryButton';
-import { ToastNotification } from '@/components/ToastNotification';
-import { useToast } from '@/hooks/useToast';
-
-// Temas y API
-import { Colors, Fonts } from '@/constants/theme';
-import vitalFitApi from '@/services/vitalfitSdk';
-import { isAPIError } from '@vitalfit/sdk';
+} from 'react-native';
 export default function LoginScreen() {
 	const { toastState, showToast, hideToast } = useToast();
 	const router = useRouter();
@@ -35,7 +30,6 @@ export default function LoginScreen() {
 	const [isLoading, setIsLoading] = useState(false);
 	const [showPassword, setShowPassword] = useState(false);
 
-	//  Manejo de login con backend ---
 	const handleLogin = async () => {
 		if (!email || !password) {
 			showToast('error', 'Error', 'Por favor, ingresa tu correo y contraseña.');
@@ -84,9 +78,9 @@ export default function LoginScreen() {
 			style={{ flex: 1 }}
 			behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
 			<TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-				<View // Reemplazado ScrollView por View
+				<View
 					style={{
-						flex: 1, // Añadir flex: 1 para ocupar todo el espacio
+						flex: 1,
 						justifyContent: 'center',
 						paddingHorizontal: 32,
 						paddingVertical: 16,
@@ -100,26 +94,21 @@ export default function LoginScreen() {
 						onClose={hideToast}
 					/>
 					<View className='w-full max-w-sm self-center'>
-						{/* Logo */}
 						<View className='items-center mb-2'>
 							<LogoSimple size={250} />
 						</View>
 
-						{/* Título */}
 						<Text
 							className='text-4xl text-black mb-2 uppercase text-center'
 							style={{ fontFamily: Fonts.title }}>
 							Iniciar Sesión
 						</Text>
 
-						{/* Subtítulo */}
 						<Text className='text-gray-500 text-center mb-8 text-lg'>
 							Ingresa tus credenciales para iniciar sesión
 						</Text>
 
-						{/* Inputs */}
 						<View className='px-2 mt-6 gap-6'>
-							{/* Correo */}
 							<View className='mb-4'>
 								<Text className='text-black font-bold text-sm mb-1 ml-1'>
 									Correo electrónico
@@ -135,7 +124,6 @@ export default function LoginScreen() {
 								/>
 							</View>
 
-							{/* Contraseña */}
 							<View className='mb-4'>
 								<View className='flex-row items-center mb-1 ml-1'>
 									<SlidersVertical
@@ -167,7 +155,6 @@ export default function LoginScreen() {
 							</View>
 						</View>
 
-						{/* Checkbox y link */}
 						<View className='w-full flex-row justify-between items-center my-4'>
 							<View className='flex-row items-center'>
 								<Checkbox
@@ -195,7 +182,6 @@ export default function LoginScreen() {
 							</Link>
 						</View>
 
-						{/* Botones */}
 						<View className='gap-4 mb-4'>
 							<PrimaryButton
 								title={isLoading ? 'Iniciando...' : 'Iniciar sesión'}
@@ -205,7 +191,6 @@ export default function LoginScreen() {
 							<SocialButton title='Sign in with Google' iconName='google' />
 						</View>
 
-						{/* Registro (Margin ajustado) */}
 						<View className='mt-1 flex-row justify-center items-center'>
 							<Text className='text-gray-600'>¿No tienes cuenta aún? </Text>
 							<Link href='/(auth)/register' asChild>

--- a/app/(auth)/register.tsx
+++ b/app/(auth)/register.tsx
@@ -1,5 +1,3 @@
-// RegisterScreen.tsx
-
 import { Logo } from '@/components/auth/Logo';
 import { Step1Gender } from '@/components/auth/register/Step1Gender';
 import { Step2Credentials } from '@/components/auth/register/Step2Credentials';
@@ -37,7 +35,7 @@ export default function RegisterScreen() {
 	});
 
 	const handleRegistration = async (data: RegisterData) => {
-		console.log('📤 Enviando datos:', data);
+		console.log('Enviando datos:', data);
 
 		const allowedKeys = [
 			'gender',
@@ -72,16 +70,15 @@ export default function RegisterScreen() {
 				profile_picture_url: '', // El SDK espera esto, aunque esté vacío
 			};
 
-			// 🔹 Registro del usuario
+			// Registro del usuario
 			await vitalFitApi.auth.signUp(payload);
 
-			// 🔹 Guardamos las credenciales temporalmente para el login post-activación
+			//Guardamos las credenciales temporalmente para el login post-activación
 			await AsyncStorage.setItem('temp_email', cleanedData.email);
 			await AsyncStorage.setItem('temp_password', cleanedData.password);
 
-			console.log('✅ Registro exitoso, credenciales temporales guardadas.');
+			console.log('Registro exitoso, credenciales temporales guardadas.');
 
-			// Mostrar toast de éxito
 			showToast('success', 'Revisa tu correo', 'Código enviado correctamente');
 
 			// Redirigir después de 2 segundos
@@ -96,7 +93,7 @@ export default function RegisterScreen() {
 			} else if (error instanceof Error) {
 				errorMessage = error.message;
 			}
-			console.error('❌ Error al registrar:', error);
+			console.error('Error al registrar:', error);
 			showToast('error', 'Error al registrar', errorMessage);
 		}
 	};
@@ -131,7 +128,6 @@ export default function RegisterScreen() {
 			style={styles.keyboardView}
 			behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
 			keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 20}>
-			{/* 🔹 ToastNotification FUERA del ScrollView */}
 			<ToastNotification
 				visible={toastState.visible}
 				type={toastState.type}

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -11,8 +11,6 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { isAPIError } from '@vitalfit/sdk';
 import React, { useEffect, useState } from 'react';
 import { ActivityIndicator, ScrollView } from 'react-native';
-
-// 👉 importa las versiones internas del dashboard
 import DashboardInstructor from '../dashboards/dashboard-instructor';
 import DashboardRecepcionist from '../dashboards/dashboard-recepcionist';
 
@@ -27,7 +25,6 @@ export default function DashboardScreen() {
 		const fetchUser = async () => {
 			try {
 				const token = await AsyncStorage.getItem('token');
-
 				if (!token) {
 					console.error('No se encontró token en AsyncStorage');
 					return;
@@ -37,11 +34,9 @@ export default function DashboardScreen() {
 
 				const userData = await vitalFitApi.user.WhoAmI(token);
 
-				// ⚙️ Temporal para probar:
-				// const roleName = userData?.user?.role?.name || '';
-				// setUserRole(roleName);
-				setUserRole('recepcionist'); // 👈 Cambia entre 'instructor', 'recepcionist' o 'client'
+				const roleName = userData?.user?.role?.name?.toLowerCase() || '';
 
+				setUserRole(roleName);
 				setFirstName(userData?.user?.first_name || 'Usuario');
 			} catch (error: unknown) {
 				let errorMessage = 'Ocurrió un error inesperado al obtener los datos del usuario.';
@@ -67,37 +62,41 @@ export default function DashboardScreen() {
 		);
 	}
 
-	// 🧠 Render condicional
-	if (userRole === 'instructor') return <DashboardInstructor />;
-	if (userRole === 'recepcionist') return <DashboardRecepcionist />;
+	switch (userRole) {
+		case 'instructor':
+			return <DashboardInstructor />;
+		case 'recepcionist':
+		case 'receptionist':
+			return <DashboardRecepcionist />;
+		default:
+			return (
+				<ThemedView className='flex-1 bg-white dark:bg-neutral-950 px-4 pt-10'>
+					<ScrollView showsVerticalScrollIndicator={false}>
+						<UserHeader
+							name={firstName ?? 'Usuario'}
+							message='Es hora de desafiar tus límites'
+							avatarUrl='https://randomuser.me/api/portraits/men/32.jpg'
+						/>
+						<WeekCalendar />
+						<MembershipCard
+							daysRemaining={15}
+							onQRPress={() => setQrModalVisible(true)}
+						/>
+						<ProgressCard weekProgress={0.8} calories={1200} completed='4/5' />
+						<ReservedClassesCard reserved={0} />
+						<TodayRoutineCard
+							title='Day 05 - Warm Up'
+							time='07:00 - 08:00 AM'
+							date='Mon 26 Apr'
+						/>
+					</ScrollView>
 
-	// 👇 Dashboard por defecto (clientes)
-	return (
-		<ThemedView className='flex-1 bg-white dark:bg-neutral-950 px-4 pt-10'>
-			<ScrollView showsVerticalScrollIndicator={false}>
-				<UserHeader
-					name={firstName ?? 'Usuario'}
-					message='Es hora de desafiar tus límites'
-					avatarUrl='https://randomuser.me/api/portraits/men/32.jpg'
-				/>
-				<WeekCalendar />
-
-				<MembershipCard daysRemaining={15} onQRPress={() => setQrModalVisible(true)} />
-
-				<ProgressCard weekProgress={0.8} calories={1200} completed='4/5' />
-				<ReservedClassesCard reserved={0} />
-				<TodayRoutineCard
-					title='Day 05 - Warm Up'
-					time='07:00 - 08:00 AM'
-					date='Mon 26 Apr'
-				/>
-			</ScrollView>
-
-			<QRModal
-				visible={qrModalVisible}
-				onClose={() => setQrModalVisible(false)}
-				token={userToken}
-			/>
-		</ThemedView>
-	);
+					<QRModal
+						visible={qrModalVisible}
+						onClose={() => setQrModalVisible(false)}
+						token={userToken}
+					/>
+				</ThemedView>
+			);
+	}
 }

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -12,11 +12,16 @@ import { isAPIError } from '@vitalfit/sdk';
 import React, { useEffect, useState } from 'react';
 import { ActivityIndicator, ScrollView } from 'react-native';
 
+// 👉 importa las versiones internas del dashboard
+import DashboardInstructor from '../dashboards/dashboard-instructor';
+import DashboardRecepcionist from '../dashboards/dashboard-recepcionist';
+
 export default function DashboardScreen() {
 	const [firstName, setFirstName] = useState<string | null>(null);
 	const [loading, setLoading] = useState(true);
-	const [qrModalVisible, setQrModalVisible] = useState(false); // 👈 Estado del modal
-	const [userToken, setUserToken] = useState<string>(''); // 👈 Estado del token
+	const [qrModalVisible, setQrModalVisible] = useState(false);
+	const [userToken, setUserToken] = useState<string>('');
+	const [userRole, setUserRole] = useState<string>('');
 
 	useEffect(() => {
 		const fetchUser = async () => {
@@ -24,13 +29,18 @@ export default function DashboardScreen() {
 				const token = await AsyncStorage.getItem('token');
 
 				if (!token) {
-					console.error('❌ No se encontró token en AsyncStorage');
+					console.error('No se encontró token en AsyncStorage');
 					return;
 				}
 
-				setUserToken(token); // 👈 Guardar token
+				setUserToken(token);
 
 				const userData = await vitalFitApi.user.WhoAmI(token);
+
+				// ⚙️ Temporal para probar:
+				// const roleName = userData?.user?.role?.name || '';
+				// setUserRole(roleName);
+				setUserRole('recepcionist'); // 👈 Cambia entre 'instructor', 'recepcionist' o 'client'
 
 				setFirstName(userData?.user?.first_name || 'Usuario');
 			} catch (error: unknown) {
@@ -40,7 +50,7 @@ export default function DashboardScreen() {
 				} else if (error instanceof Error) {
 					errorMessage = error.message;
 				}
-				console.error('💥 Error en la solicitud whoami:', errorMessage);
+				console.error('Error en la solicitud whoami:', errorMessage);
 			} finally {
 				setLoading(false);
 			}
@@ -57,6 +67,11 @@ export default function DashboardScreen() {
 		);
 	}
 
+	// 🧠 Render condicional
+	if (userRole === 'instructor') return <DashboardInstructor />;
+	if (userRole === 'recepcionist') return <DashboardRecepcionist />;
+
+	// 👇 Dashboard por defecto (clientes)
 	return (
 		<ThemedView className='flex-1 bg-white dark:bg-neutral-950 px-4 pt-10'>
 			<ScrollView showsVerticalScrollIndicator={false}>
@@ -67,11 +82,7 @@ export default function DashboardScreen() {
 				/>
 				<WeekCalendar />
 
-				{/* MembershipCard ahora abre el modal QR */}
-				<MembershipCard
-					daysRemaining={15}
-					onQRPress={() => setQrModalVisible(true)} // 👈 Abrir modal
-				/>
+				<MembershipCard daysRemaining={15} onQRPress={() => setQrModalVisible(true)} />
 
 				<ProgressCard weekProgress={0.8} calories={1200} completed='4/5' />
 				<ReservedClassesCard reserved={0} />
@@ -82,7 +93,6 @@ export default function DashboardScreen() {
 				/>
 			</ScrollView>
 
-			{/* Modal QR */}
 			<QRModal
 				visible={qrModalVisible}
 				onClose={() => setQrModalVisible(false)}

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -52,7 +52,7 @@ export default function ProfileScreen() {
 				} else if (error instanceof Error) {
 					errorMessage = error.message;
 				}
-				console.error('💥 Error en la solicitud whoami:', errorMessage);
+				console.error('Error en la solicitud whoami:', errorMessage);
 			} finally {
 				setLoading(false);
 			}
@@ -71,7 +71,6 @@ export default function ProfileScreen() {
 
 	return (
 		<View className='flex-1 bg-white dark:bg-neutral-950'>
-			{/* Header con foto de perfil y nombre */}
 			<View className='items-center justify-center py-16 bg-white dark:bg-neutral-900'>
 				<View className='w-40 h-40 rounded-full mb-6 overflow-hidden bg-neutral-200 dark:bg-neutral-800'>
 					<Image
@@ -87,7 +86,6 @@ export default function ProfileScreen() {
 				</ThemedText>
 			</View>
 
-			{/* Menú de opciones */}
 			<View className='bg-white dark:bg-neutral-900'>
 				<Link href='/my-profile' asChild>
 					<ProfileMenuItem title='Mi perfil' />

--- a/app/(tabs)/schedule.tsx
+++ b/app/(tabs)/schedule.tsx
@@ -8,32 +8,30 @@ import { useRouter } from 'expo-router';
 import React, { useState } from 'react';
 import { ScrollView, TouchableOpacity, View } from 'react-native';
 
-// Sample data for classes
 const classes = [
 	{
 		time: '12:00 PM',
 		title: 'Zumba',
 		instructor: 'Con Laura Torres',
 		branch: 'Sucursal Sur',
-		imageUrl: require('@/assets/images/yoga.png'), // Using yoga image as placeholder
+		imageUrl: require('@/assets/images/yoga.png'),
 	},
 	{
 		time: '11:00 AM',
 		title: 'Spinning',
 		instructor: 'Con Carlos Mendoza',
 		branch: 'Sucursal Norte',
-		imageUrl: require('@/assets/images/espini.png'), // Using spinning image as placeholder
+		imageUrl: require('@/assets/images/espini.png'),
 	},
 	{
 		time: '10:00 AM',
 		title: 'Yoga Flow',
 		instructor: 'Con Sofia Ramirez',
 		branch: 'Sucursal Centro',
-		imageUrl: require('@/assets/images/yoga.png'), // Using yoga image as placeholder
+		imageUrl: require('@/assets/images/yoga.png'),
 	},
 ];
 
-// Define the type for reservation data
 type Reservation = {
 	time: string;
 	title: string;
@@ -43,7 +41,6 @@ type Reservation = {
 	status: 'assisted' | 'absent' | 'cancelled';
 };
 
-// Sample data for reservations
 const reservations: Reservation[] = [
 	{
 		time: '10:00 AM',
@@ -71,7 +68,6 @@ const reservations: Reservation[] = [
 	},
 ];
 
-// Sample data for filters
 const days = ['Lun', 'Mar', 'Mie', 'Jue', 'Vie', 'Sab', 'Dom'];
 
 export default function HorariosScreen() {
@@ -91,7 +87,6 @@ export default function HorariosScreen() {
 			<ScrollView showsVerticalScrollIndicator={false}>
 				<ThemedText className='text-3xl font-bold mb-6'>Horarios</ThemedText>
 
-				{/* Tabs */}
 				<View className='flex-row mb-6'>
 					<TouchableOpacity
 						onPress={() => setActiveTab('classes')}
@@ -127,7 +122,6 @@ export default function HorariosScreen() {
 					</TouchableOpacity>
 				</View>
 
-				{/* Filters */}
 				<View className='mb-6'>
 					<View className='flex-row flex-wrap mb-2'>
 						{days.map((day) => (
@@ -152,7 +146,6 @@ export default function HorariosScreen() {
 					</TouchableOpacity>
 				</View>
 
-				{/* Tabs content */}
 				{activeTab === 'classes' && (
 					<View>
 						{classes.map((classItem, index) => (

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,4 +1,3 @@
-// app/_layout.tsx
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { useFonts } from 'expo-font';

--- a/app/cancel-membership.tsx
+++ b/app/cancel-membership.tsx
@@ -25,7 +25,6 @@ export default function CancelMembershipScreen() {
 					<PrimaryButton
 						title='Cancelar membresía'
 						onPress={() => {
-							// Lógica para cancelar la membresía
 							console.log('Membresía cancelada');
 							router.back();
 						}}

--- a/app/class-details.tsx
+++ b/app/class-details.tsx
@@ -14,7 +14,7 @@ export default function ClassDetailsScreen() {
 		<ThemedView className='flex-1 bg-white dark:bg-neutral-950 p-4'>
 			<ScrollView showsVerticalScrollIndicator={false}>
 				<Image
-					source={{ uri: imageUrl as string }} // Ensure imageUrl is treated as a string URI
+					source={{ uri: imageUrl as string }}
 					style={styles.heroImage}
 					contentFit='cover'
 				/>
@@ -28,7 +28,6 @@ export default function ClassDetailsScreen() {
 					<ThemedText className='text-lg font-semibold mb-1'>
 						Hora: {time as string}
 					</ThemedText>
-					{/* Add other details like date, duration, description, location, equipment, difficulty */}
 				</View>
 
 				<View className='flex-row justify-between mb-6'>

--- a/app/dashboards/dashboard-instructor.tsx
+++ b/app/dashboards/dashboard-instructor.tsx
@@ -15,7 +15,7 @@ type TabType = 'clientes' | 'clases' | 'mensajes';
 export default function DashboardInstructor() {
 	const [loading, setLoading] = useState(true);
 	const [firstName, setFirstName] = useState<string | null>(null);
-	const [activeTab, setActiveTab] = useState<TabType>('clientes'); // ✅ Estado para el tab activo
+	const [activeTab, setActiveTab] = useState<TabType>('clientes');
 
 	useEffect(() => {
 		const fetchUser = async () => {

--- a/app/dashboards/dashboard-instructor.tsx
+++ b/app/dashboards/dashboard-instructor.tsx
@@ -1,0 +1,80 @@
+import { InstructorStatsCardGroup } from '@/components/auth/dashboard/InstructorStatsCardGroup';
+import { InstructorTabs } from '@/components/auth/dashboard/InstructorTabs';
+import { MyClientsCardGroup } from '@/components/auth/dashboard/MyClientsCardGroup';
+import { TodayClassCard } from '@/components/auth/dashboard/TodayClassCard';
+import { UserHeader } from '@/components/auth/dashboard/userheader';
+import { ThemedView } from '@/components/themed-view';
+import vitalFitApi from '@/services/vitalfitSdk';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { isAPIError } from '@vitalfit/sdk';
+import React, { useEffect, useState } from 'react';
+import { ActivityIndicator, ScrollView, Text, View } from 'react-native';
+
+type TabType = 'clientes' | 'clases' | 'mensajes';
+
+export default function DashboardInstructor() {
+	const [loading, setLoading] = useState(true);
+	const [firstName, setFirstName] = useState<string | null>(null);
+	const [activeTab, setActiveTab] = useState<TabType>('clientes'); // ✅ Estado para el tab activo
+
+	useEffect(() => {
+		const fetchUser = async () => {
+			try {
+				const token = await AsyncStorage.getItem('token');
+				if (!token) {
+					console.error('No se encontró token en AsyncStorage');
+					return;
+				}
+
+				const userData = await vitalFitApi.user.WhoAmI(token);
+				setFirstName(userData?.user?.first_name || 'Instructor');
+			} catch (error: unknown) {
+				let errorMessage = 'Ocurrió un error inesperado al obtener los datos del usuario.';
+				if (isAPIError(error)) {
+					errorMessage = error.messages.join(', ');
+				} else if (error instanceof Error) {
+					errorMessage = error.message;
+				}
+				console.error('Error en la solicitud whoami (Instructor):', errorMessage);
+			} finally {
+				setLoading(false);
+			}
+		};
+
+		fetchUser();
+	}, []);
+
+	if (loading) {
+		return (
+			<ThemedView className='flex-1 justify-center items-center bg-white dark:bg-neutral-950'>
+				<ActivityIndicator size='large' color='#F27F2A' />
+			</ThemedView>
+		);
+	}
+
+	return (
+		<ThemedView className='flex-1 bg-white dark:bg-neutral-950 px-4 pt-10'>
+			<ScrollView showsVerticalScrollIndicator={false}>
+				<UserHeader
+					name={firstName ?? 'Instructor'}
+					message='Gestiona tus clases y alumnos'
+					avatarUrl='https://randomuser.me/api/portraits/men/31.jpg'
+				/>
+
+				<InstructorStatsCardGroup />
+
+				<InstructorTabs activeTab={activeTab} onChange={setActiveTab} />
+
+				{activeTab === 'clientes' && <MyClientsCardGroup />}
+				{activeTab === 'clases' && <TodayClassCard />}
+				{activeTab === 'mensajes' && (
+					<View className='mt-6'>
+						<Text className='text-[#71727A] text-[14px] text-center'>
+							Aún no tienes mensajes nuevos
+						</Text>
+					</View>
+				)}
+			</ScrollView>
+		</ThemedView>
+	);
+}

--- a/app/dashboards/dashboard-recepcionist.tsx
+++ b/app/dashboards/dashboard-recepcionist.tsx
@@ -1,17 +1,61 @@
+import { GymCapacityCard } from '@/components/auth/dashboard/GymCapacityCard';
+import { RecepcionistStatsCardGroup } from '@/components/auth/dashboard/RecepcionistStatsCardGroup';
+import { RecepcionistTodayClassCard } from '@/components/auth/dashboard/RecepcionistTodayClassCard';
+import { UserHeader } from '@/components/auth/dashboard/userheader';
+import { ValidateCheckInCard } from '@/components/auth/dashboard/ValidateCheckInCard';
 import { ThemedView } from '@/components/themed-view';
-import React from 'react';
-import { Text } from 'react-native';
+import vitalFitApi from '@/services/vitalfitSdk';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { isAPIError } from '@vitalfit/sdk';
+import React, { useEffect, useState } from 'react';
+import { ActivityIndicator, ScrollView } from 'react-native';
 
 export default function DashboardRecepcionist() {
+	const [loading, setLoading] = useState(true);
+	const [firstName, setFirstName] = useState<string | null>(null);
+
+	useEffect(() => {
+		const fetchUser = async () => {
+			try {
+				const token = await AsyncStorage.getItem('token');
+				if (!token) return;
+				const userData = await vitalFitApi.user.WhoAmI(token);
+				setFirstName(userData?.user?.first_name || 'Recepcionista');
+			} catch (error: unknown) {
+				let errorMessage = 'Ocurrió un error inesperado.';
+				if (isAPIError(error)) errorMessage = error.messages.join(', ');
+				else if (error instanceof Error) errorMessage = error.message;
+				console.error('Error whoami (Recepcionista):', errorMessage);
+			} finally {
+				setLoading(false);
+			}
+		};
+
+		fetchUser();
+	}, []);
+
+	if (loading) {
+		return (
+			<ThemedView className='flex-1 justify-center items-center bg-white dark:bg-neutral-950'>
+				<ActivityIndicator size='large' color='#F27F2A' />
+			</ThemedView>
+		);
+	}
+
 	return (
-		<ThemedView className='flex-1 justify-center items-center bg-white dark:bg-neutral-950'>
-			<Text className='text-2xl font-semibold text-neutral-900 dark:text-white'>
-				🧾 Dashboard del Recepcionista
-			</Text>
-			<Text className='mt-2 text-neutral-700 dark:text-neutral-300 text-center px-6'>
-				Bienvenido al panel del recepcionista. Aquí podrás ver y gestionar los check-ins,
-				clases reservadas y asistencia de los clientes.
-			</Text>
+		<ThemedView className='flex-1 bg-white dark:bg-neutral-950 px-4 pt-10'>
+			<ScrollView showsVerticalScrollIndicator={false}>
+				<UserHeader
+					name={firstName ?? 'Recepcionista'}
+					message='Bienvenido a VITALFIT'
+					avatarUrl='https://randomuser.me/api/portraits/women/44.jpg'
+				/>
+
+				<RecepcionistStatsCardGroup />
+				<ValidateCheckInCard />
+				<GymCapacityCard />
+				<RecepcionistTodayClassCard />
+			</ScrollView>
 		</ThemedView>
 	);
 }

--- a/app/dashboards/dashboard-recepcionist.tsx
+++ b/app/dashboards/dashboard-recepcionist.tsx
@@ -1,0 +1,17 @@
+import { ThemedView } from '@/components/themed-view';
+import React from 'react';
+import { Text } from 'react-native';
+
+export default function DashboardRecepcionist() {
+	return (
+		<ThemedView className='flex-1 justify-center items-center bg-white dark:bg-neutral-950'>
+			<Text className='text-2xl font-semibold text-neutral-900 dark:text-white'>
+				🧾 Dashboard del Recepcionista
+			</Text>
+			<Text className='mt-2 text-neutral-700 dark:text-neutral-300 text-center px-6'>
+				Bienvenido al panel del recepcionista. Aquí podrás ver y gestionar los check-ins,
+				clases reservadas y asistencia de los clientes.
+			</Text>
+		</ThemedView>
+	);
+}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,4 +1,3 @@
-// app/index.tsx
 import { Montserrat_500Medium, Montserrat_700Bold, useFonts } from '@expo-google-fonts/montserrat';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
@@ -22,7 +21,6 @@ export default function HomeScreen() {
 		<View className='flex-1 bg-black'>
 			<StatusBar barStyle='light-content' backgroundColor='#000' />
 
-			{/* Carrusel a pantalla completa */}
 			<BackgroundCarousel
 				images={[
 					require('../assets/images/slide1.jpg'),
@@ -32,7 +30,6 @@ export default function HomeScreen() {
 				onIndexChange={setIndex}
 			/>
 
-			{/* Logo centrado */}
 			<View
 				className='absolute inset-0 items-center justify-center'
 				style={{ top: '-10%' }}
@@ -44,7 +41,6 @@ export default function HomeScreen() {
 				/>
 			</View>
 
-			{/* Degradado inferior + contenido */}
 			<LinearGradient
 				colors={['transparent', 'rgba(0,0,0,0.7)', 'black']}
 				style={{
@@ -56,7 +52,6 @@ export default function HomeScreen() {
 					paddingHorizontal: 24,
 					paddingTop: 48,
 				}}>
-				{/* Texto dinámico */}
 				<Text className='text-white text-[30px] font-montserrat-bold text-center leading-[36px] mb-6'>
 					{
 						[
@@ -67,7 +62,6 @@ export default function HomeScreen() {
 					}
 				</Text>
 
-				{/* Dots */}
 				<View className='flex-row justify-center mb-6'>
 					{[0, 1, 2].map((i) => (
 						<View
@@ -79,7 +73,6 @@ export default function HomeScreen() {
 					))}
 				</View>
 
-				{/* Botones alineados */}
 				<View
 					style={{
 						flexDirection: 'row',

--- a/app/memberships.tsx
+++ b/app/memberships.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
-// Datos de ejemplo para las membresías
 const membershipPlans = [
 	{
 		title: 'Básico',

--- a/app/my-profile.tsx
+++ b/app/my-profile.tsx
@@ -111,7 +111,7 @@ export default function MyProfileScreen() {
 			} else if (error instanceof Error) {
 				errorMessage = error.message;
 			}
-			console.error('💥 Error al actualizar el perfil:', errorMessage);
+			console.error('Error al actualizar el perfil:', errorMessage);
 			setToast({
 				visible: true,
 				type: 'error',
@@ -144,7 +144,6 @@ export default function MyProfileScreen() {
 				onClose={() => setToast({ ...toast, visible: false })}
 			/>
 
-			{/* Header */}
 			<View className='flex-row items-center justify-center pt-14 pb-4 px-4 bg-white dark:bg-neutral-900 relative'>
 				<TouchableOpacity onPress={() => router.back()} className='absolute left-4 top-14'>
 					<ChevronLeftIcon size={28} color='#F27F2A' />
@@ -155,7 +154,6 @@ export default function MyProfileScreen() {
 			</View>
 
 			<ScrollView className='flex-1 bg-white dark:bg-neutral-950'>
-				{/* Profile Image Section */}
 				<View className='items-center py-8 bg-white dark:bg-neutral-900'>
 					<View className='relative'>
 						<View className='w-32 h-32 rounded-full overflow-hidden bg-neutral-200 dark:bg-neutral-800'>
@@ -181,7 +179,6 @@ export default function MyProfileScreen() {
 					</ThemedText>
 				</View>
 
-				{/* Form Section */}
 				<View className='px-6 py-4'>
 					<StyledTextInput
 						label='Nombre'
@@ -213,7 +210,6 @@ export default function MyProfileScreen() {
 					/>
 					<View className='mb-4' />
 
-					{/* Campo de fecha de nacimiento con calendario */}
 					<TouchableOpacity
 						onPress={() => isEditing && setShowPicker(true)}
 						style={{ position: 'relative' }}
@@ -248,7 +244,6 @@ export default function MyProfileScreen() {
 					)}
 					<View className='mb-4' />
 
-					{/* Campo de teléfono internacional */}
 					<View>
 						<Text style={styles.label}>Teléfono</Text>
 						<PhoneInput
@@ -274,7 +269,6 @@ export default function MyProfileScreen() {
 					</View>
 				</View>
 
-				{/* Action Button */}
 				<View className='px-6 mt-2 mb-10'>
 					<PrimaryButton
 						title={isEditing ? 'Guardar cambios' : 'Editar'}

--- a/app/notification-settings.tsx
+++ b/app/notification-settings.tsx
@@ -6,7 +6,6 @@ import { ScrollView, Switch, Text, TouchableOpacity, View } from 'react-native';
 import { BellIcon } from 'react-native-heroicons/outline';
 import { ChevronLeftIcon } from 'react-native-heroicons/solid';
 
-// Mock Data for notification settings
 const mockSettings = [
 	{ id: '1', label: 'New offer available' },
 	{ id: '2', label: 'New offer available' },
@@ -16,7 +15,6 @@ const mockSettings = [
 	{ id: '6', label: 'New offer available' },
 ];
 
-// Setting Item Component
 const SettingItem = ({ label }: { label: string }) => {
 	const [isEnabled, setIsEnabled] = useState(false);
 	const toggleSwitch = () => setIsEnabled((previousState) => !previousState);

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -6,7 +6,6 @@ import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import { BellIcon, Cog6ToothIcon } from 'react-native-heroicons/outline';
 import { ChevronLeftIcon } from 'react-native-heroicons/solid';
 
-// Mock Data for notifications
 const mockNotifications = [
 	{
 		id: '1',
@@ -40,7 +39,6 @@ const mockNotifications = [
 	},
 ];
 
-// Notification Item Component
 const NotificationItem = ({ title, description }: { title: string; description: string }) => (
 	<View className='flex-row items-start p-4 bg-white dark:bg-neutral-900'>
 		<View className='w-12 h-12 rounded-lg bg-neutral-200 dark:bg-neutral-800 items-center justify-center mr-3'>
@@ -62,7 +60,6 @@ export default function NotificationsScreen() {
 		<View className='flex-1 bg-white dark:bg-neutral-900'>
 			<Stack.Screen options={{ headerShown: false }} />
 
-			{/* Header */}
 			<View className='flex-row items-center justify-between pt-14 pb-4 px-4 bg-white dark:bg-neutral-900'>
 				<TouchableOpacity onPress={() => router.back()} className='p-2'>
 					<ChevronLeftIcon size={28} color='#F27F2A' />

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -83,7 +83,6 @@ export default function SettingsScreen() {
 		<View className='flex-1 bg-white dark:bg-neutral-900'>
 			<Stack.Screen options={{ headerShown: false }} />
 
-			{/* Header */}
 			<View className='flex-row items-center justify-center pt-14 pb-4 px-4 bg-white dark:bg-neutral-900 relative'>
 				<TouchableOpacity onPress={() => router.back()} className='absolute left-4 top-14'>
 					<ChevronLeftIcon size={28} color='#F27F2A' />
@@ -94,10 +93,8 @@ export default function SettingsScreen() {
 			</View>
 
 			<ScrollView className='bg-white dark:bg-neutral-900 px-4'>
-				{/* Menú de opciones */}
 				<View>
 					<SectionHeader title='Aplicación' />
-					{/* Contenedor 1: Solo Notificaciones Push */}
 					<View className='rounded-xl overflow-hidden mb-3'>
 						<SettingsToggleItem
 							title='Notificaciones Push'
@@ -107,7 +104,6 @@ export default function SettingsScreen() {
 					</View>
 
 					<SectionHeader title='Cuenta' />
-					{/* Contenedor 2: Opciones de cuenta */}
 					<View className='rounded-xl overflow-hidden'>
 						<SettingsMenuItem
 							title='Cambiar contraseña'
@@ -136,7 +132,6 @@ export default function SettingsScreen() {
 				</View>
 			</ScrollView>
 
-			{/* Modal de confirmación de cierre de sesión */}
 			<Modal
 				visible={showLogoutModal}
 				transparent={true}

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,13 +2,7 @@
 module.exports = function (api) {
 	api.cache(true);
 	return {
-		presets: [
-			// Pasa el plugin de NativeWind como una opción al preset de Expo
-			['babel-preset-expo', { jsxImportSource: 'nativewind' }],
-		],
-		plugins: [
-			// Ya no necesitas 'nativewind/babel' aquí, pero sí necesitas el plugin de reanimated
-			'react-native-reanimated/plugin',
-		],
+		presets: [['babel-preset-expo', { jsxImportSource: 'nativewind' }]],
+		plugins: ['react-native-reanimated/plugin'],
 	};
 };

--- a/components/AuthLink.tsx
+++ b/components/AuthLink.tsx
@@ -1,1 +1,1 @@
-//Enlace de texto (ej: Iniciar sesión)
+//

--- a/components/ClassCard.tsx
+++ b/components/ClassCard.tsx
@@ -3,7 +3,6 @@ import { Image } from 'expo-image';
 import React from 'react';
 import { TouchableOpacity, View } from 'react-native';
 
-// Define the type for class data passed to onPress
 type ClassData = {
 	time: string;
 	title: string;
@@ -18,7 +17,7 @@ type ClassCardProps = {
 	instructor: string;
 	branch: string;
 	imageUrl: string;
-	onPress: (classData: ClassData) => void; // Use the specific type
+	onPress: (classData: ClassData) => void;
 };
 
 export default function ClassCard({
@@ -33,7 +32,7 @@ export default function ClassCard({
 
 	return (
 		<TouchableOpacity
-			onPress={() => onPress(classData)} // Pass class data to onPress
+			onPress={() => onPress(classData)}
 			className='bg-white dark:bg-neutral-900 rounded-2xl p-4 mb-4 flex-row items-center'>
 			<View className='flex-1'>
 				<ThemedText className='text-sm text-neutral-500'>{time}</ThemedText>
@@ -42,7 +41,7 @@ export default function ClassCard({
 					{instructor} · {branch}
 				</ThemedText>
 				<TouchableOpacity
-					onPress={() => onPress(classData)} // Pass class data to onPress
+					onPress={() => onPress(classData)}
 					className='bg-neutral-100 dark:bg-neutral-800 rounded-full py-2 px-4 mt-4 self-start'>
 					<ThemedText className='font-semibold'>Ver Detalles</ThemedText>
 				</TouchableOpacity>

--- a/components/CodeInput.tsx
+++ b/components/CodeInput.tsx
@@ -1,5 +1,3 @@
-// components/auth/CodeInput.tsx
-
 import { useRef, useState } from 'react';
 import { NativeSyntheticEvent, TextInput, TextInputKeyPressEventData, View } from 'react-native';
 
@@ -48,12 +46,12 @@ export function CodeInput({ onComplete, hasError }: Props) {
               w-12 h-14 border rounded-lg text-center text-2xl font-bold text-black dark:text-white
               ${hasError ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'}
             `}
-						keyboardType='default' // 👈 CAMBIO: de 'number-pad' a 'default'
+						keyboardType='default'
 						maxLength={1}
 						value={code[index]}
 						onChangeText={(text) => handleTextChange(text, index)}
 						onKeyPress={(e) => handleKeyPress(e, index)}
-						autoCapitalize='characters' // Opcional: para mostrar letras en mayúsculas
+						autoCapitalize='characters'
 					/>
 				))}
 		</View>

--- a/components/PrimaryButton.tsx
+++ b/components/PrimaryButton.tsx
@@ -1,6 +1,3 @@
-//Botón principal (naranja)
-// components/auth/PrimaryButton.tsx
-
 import { Colors } from '@/constants/theme';
 import { Text, TouchableOpacity, type TouchableOpacityProps } from 'react-native';
 
@@ -12,7 +9,7 @@ export function PrimaryButton({ title, ...props }: Props) {
 	return (
 		<TouchableOpacity
 			className='h-12 w-full items-center justify-center rounded-md'
-			style={{ backgroundColor: Colors.light.tint }} // Usamos el color Naranja Vital del tema
+			style={{ backgroundColor: Colors.light.tint }}
 			{...props}>
 			<Text className='text-white text-base font-bold'>{title}</Text>
 		</TouchableOpacity>

--- a/components/ProgressIndicator.tsx
+++ b/components/ProgressIndicator.tsx
@@ -1,4 +1,3 @@
-// components/auth/ProgressIndicator.tsx
 import { ThemedView } from '@/components/themed-view';
 import { Text, View } from 'react-native';
 

--- a/components/SecondaryButton.tsx
+++ b/components/SecondaryButton.tsx
@@ -1,4 +1,3 @@
-// components/auth/SecondaryButton.tsx
 import { Text, TouchableOpacity, type TouchableOpacityProps } from 'react-native';
 
 interface Props extends TouchableOpacityProps {

--- a/components/StyledTextInput.tsx
+++ b/components/StyledTextInput.tsx
@@ -1,5 +1,3 @@
-// components/auth/StyledTextInput.tsx
-
 import { Colors } from '@/constants/theme';
 import { Eye, EyeOff } from 'lucide-react-native'; // Importa los íconos
 import { forwardRef, useState } from 'react';
@@ -9,15 +7,14 @@ interface Props extends TextInputProps {
 	label?: string;
 	error?: string;
 	helperText?: string;
-	isPasswordInput?: boolean; // Nuevo prop para indicar si es un campo de contraseña
-	icon?: React.ReactNode; // Prop para el ícono
+	isPasswordInput?: boolean;
+	icon?: React.ReactNode;
 }
 
 export const StyledTextInput = forwardRef<TextInput, Props>(
 	({ label, error, helperText, isPasswordInput, icon, ...props }, ref) => {
 		const isError = Boolean(error);
-		const [isPasswordVisible, setIsPasswordVisible] = useState(false); // Estado para controlar la visibilidad de la contraseña
-
+		const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 		const togglePasswordVisibility = () => {
 			setIsPasswordVisible(!isPasswordVisible);
 		};
@@ -43,7 +40,7 @@ export const StyledTextInput = forwardRef<TextInput, Props>(
               ${isPasswordInput ? 'pr-10' : ''} // Añade padding a la derecha si es campo de contraseña
             `}
 						placeholderTextColor={Colors.light.icon}
-						secureTextEntry={isPasswordInput ? !isPasswordVisible : false} // Controla la seguridad del texto
+						secureTextEntry={isPasswordInput ? !isPasswordVisible : false}
 						{...props}
 					/>
 					{isPasswordInput && (
@@ -59,7 +56,6 @@ export const StyledTextInput = forwardRef<TextInput, Props>(
 						</TouchableOpacity>
 					)}
 				</View>
-				{/* 👇 LÍNEA CORREGIDA AQUÍ 👇 */}
 				{(helperText || error) && (
 					<Text className={`mt-1 text-xs ${isError ? 'text-red-500' : 'text-gray-500'}`}>
 						{isError ? error : helperText}

--- a/components/ToastNotification.tsx
+++ b/components/ToastNotification.tsx
@@ -1,9 +1,7 @@
-// components/ToastNotification.tsx
 import { AlertCircle, CheckCircle, XCircle } from 'lucide-react-native';
 import { useCallback, useEffect, useRef } from 'react';
 import { Animated, StyleSheet, Text, View } from 'react-native';
 
-// Se ha añadido el tipo 'warning' para coincidir con el diseño
 interface Props {
 	type: 'success' | 'error' | 'warning';
 	title: string;
@@ -48,11 +46,10 @@ export function ToastNotification({
 
 	if (!visible) return null;
 
-	// Lógica para seleccionar colores e íconos según el tipo
 	let backgroundColor: string;
 	let iconBackgroundColor: string;
 	let IconComponent: React.ElementType;
-	const titleColor = '#111827'; // Un color de título más oscuro por defecto
+	const titleColor = '#111827';
 	let messageColor = '#6B7280';
 
 	switch (type) {
@@ -99,10 +96,10 @@ const styles = StyleSheet.create({
 		top: 60,
 		left: 16,
 		right: 16,
-		borderRadius: 16, // Esquinas más redondeadas
+		borderRadius: 16,
 		padding: 16,
 		shadowColor: '#000',
-		shadowOffset: { width: 0, height: 4 }, // Sombra ajustada
+		shadowOffset: { width: 0, height: 4 },
 		shadowOpacity: 0.1,
 		shadowRadius: 10,
 		elevation: 8,
@@ -128,7 +125,7 @@ const styles = StyleSheet.create({
 	},
 	title: {
 		fontSize: 16,
-		fontWeight: '700', // Texto más grueso (bold)
+		fontWeight: '700',
 	},
 	message: {
 		fontSize: 14,

--- a/components/auth/GenderSelector.tsx
+++ b/components/auth/GenderSelector.tsx
@@ -40,9 +40,7 @@ export function GenderSelector({ onSelect, selected }: Props) {
 					onPress={() => handlePress(option.id)}
 					className={`
             w-full flex-row items-center justify-between rounded-2xl p-4
-            ${
-				internalSelected === option.id ? 'bg-gray-800' : 'bg-white' // Puedes ajustar el color de fondo para no seleccionados si es necesario
-			}
+            ${internalSelected === option.id ? 'bg-gray-800' : 'bg-white'}
           `}>
 					<View className='flex-row items-center'>
 						<Text

--- a/components/auth/SocialButton.tsx
+++ b/components/auth/SocialButton.tsx
@@ -1,5 +1,3 @@
-// components/auth/SocialButton.tsx
-
 import { AntDesign } from '@expo/vector-icons';
 import { Text, TouchableOpacity, type TouchableOpacityProps } from 'react-native';
 

--- a/components/auth/dashboard/GymCapacityCard.tsx
+++ b/components/auth/dashboard/GymCapacityCard.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import { UsersIcon } from 'react-native-heroicons/mini';
+
+export function GymCapacityCard() {
+	const totalCapacity = 100;
+	const currentOccupancy = 45;
+	const occupancyPercentage = Math.round((currentOccupancy / totalCapacity) * 100);
+	const availableSpaces = totalCapacity - currentOccupancy;
+
+	return (
+		<View className='bg-white dark:bg-neutral-900 rounded-2xl p-4 mt-4 shadow-sm border border-neutral-200 dark:border-neutral-800'>
+			<View className='flex-row items-center mb-2'>
+				<UsersIcon width={20} height={20} color='#0F172A' />
+				<Text className='ml-2 text-[16px] font-semibold text-neutral-900 dark:text-white'>
+					Aforo del Gimnasio
+				</Text>
+			</View>
+
+			<Text className='text-[14px] text-neutral-700 dark:text-neutral-400 mb-3'>
+				Capacidad actual en tiempo real
+			</Text>
+
+			<View className='flex-row items-end justify-between mb-3'>
+				<Text className='text-[15px] text-neutral-800 dark:text-neutral-400 font-medium'>
+					Ocupación
+				</Text>
+				<Text
+					style={{ fontFamily: 'BebasNeue-Regular' }}
+					className='text-[39px] leading-none text-black dark:text-white'>
+					{currentOccupancy}/{totalCapacity}
+				</Text>
+			</View>
+
+			<View className='flex-row items-center justify-between'>
+				<View className='bg-neutral-100 dark:bg-neutral-800 rounded-lg px-3 py-1'>
+					<Text className='text-[13px] text-neutral-900 dark:text-white font-medium'>
+						{occupancyPercentage}% Ocupado
+					</Text>
+				</View>
+				<Text className='text-[13px] text-neutral-600 dark:text-neutral-400'>
+					{availableSpaces} espacios disponibles
+				</Text>
+			</View>
+		</View>
+	);
+}

--- a/components/auth/dashboard/InstructorStatsCardGroup.tsx
+++ b/components/auth/dashboard/InstructorStatsCardGroup.tsx
@@ -1,0 +1,62 @@
+import { Flag2, Profile2User } from 'iconsax-react-native';
+import React from 'react';
+import { Text, View } from 'react-native';
+import { CalendarDaysIcon, CheckCircleIcon } from 'react-native-heroicons/mini';
+
+export function InstructorStatsCardGroup() {
+	return (
+		<View className='flex flex-wrap flex-row justify-between px-2 mt-4'>
+			{/* ✅ Check-ins Mensual */}
+			<View className='w-[48%] bg-white dark:bg-neutral-900 rounded-2xl p-4 mb-4 shadow-sm border border-neutral-200 dark:border-neutral-800'>
+				<View className='flex-row items-center justify-center mb-1'>
+					<CheckCircleIcon width={20} height={20} color='#22C55E' />
+					<Text className='ml-1 text-[16px] font-medium text-neutral-900 dark:text-white text-center'>
+						Check-ins Mensual
+					</Text>
+				</View>
+				<Text className='text-center text-[24px] font-semibold text-neutral-900 dark:text-white mt-1'>
+					234
+				</Text>
+			</View>
+
+			{/* 📅 Clases Esta Semana */}
+			<View className='w-[48%] bg-white dark:bg-neutral-900 rounded-2xl p-4 mb-4 shadow-sm border border-neutral-200 dark:border-neutral-800'>
+				<View className='flex-row items-center justify-center mb-1'>
+					<CalendarDaysIcon width={19.2} height={19.2} color='#F17B23' />
+					<Text className='ml-1 text-[16px] font-medium text-neutral-900 dark:text-white text-center'>
+						Clases Esta Semana
+					</Text>
+				</View>
+				<Text className='text-center text-[24px] font-semibold text-neutral-900 dark:text-white mt-1'>
+					23
+				</Text>
+			</View>
+
+			{/* 👥 Mensajes Nuevos */}
+			<View className='w-[48%] bg-white dark:bg-neutral-900 rounded-2xl p-4 mb-4 shadow-sm border border-neutral-200 dark:border-neutral-800'>
+				<View className='flex-row items-center justify-center mb-1'>
+					<Profile2User size={24} color='#9747FF' variant='Bold' />
+					<Text className='ml-1 text-[16px] font-medium text-neutral-900 dark:text-white text-center'>
+						Mensajes Nuevos
+					</Text>
+				</View>
+				<Text className='text-center text-[24px] font-semibold text-neutral-900 dark:text-white mt-1'>
+					234
+				</Text>
+			</View>
+
+			{/* 🚩 Rutinas Asignadas */}
+			<View className='w-[48%] bg-white dark:bg-neutral-900 rounded-2xl p-4 mb-4 shadow-sm border border-neutral-200 dark:border-neutral-800'>
+				<View className='flex-row items-center justify-center mb-1'>
+					<Flag2 size={24} color='#E1491B' variant='Bold' />
+					<Text className='ml-1 text-[16px] font-medium text-neutral-900 dark:text-white text-center'>
+						Rutinas Asignadas
+					</Text>
+				</View>
+				<Text className='text-center text-[24px] font-semibold text-neutral-900 dark:text-white mt-1'>
+					+12%
+				</Text>
+			</View>
+		</View>
+	);
+}

--- a/components/auth/dashboard/InstructorTabs.tsx
+++ b/components/auth/dashboard/InstructorTabs.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+
+type TabType = 'clientes' | 'clases' | 'mensajes';
+
+type Props = {
+	activeTab: TabType;
+	onChange: (tab: TabType) => void;
+};
+
+export function InstructorTabs({ activeTab, onChange }: Props) {
+	const getTextStyle = (tab: TabType) => {
+		const base = 'text-[12px] font-bold text-center';
+		return activeTab === tab ? `${base} text-[#1F2024]` : `${base} text-[#71727A]`;
+	};
+
+	return (
+		<View className='flex-row justify-between items-center bg-[#F8F9FB] dark:bg-neutral-900 rounded-2xl px-2 py-2 mt-6'>
+			{/* 🔹 Clientes */}
+			<TouchableOpacity
+				onPress={() => onChange('clientes')}
+				className={`flex-1 py-2 rounded-xl ${
+					activeTab === 'clientes' ? 'bg-white dark:bg-neutral-800' : ''
+				}`}>
+				<Text className={getTextStyle('clientes')}>Clientes</Text>
+			</TouchableOpacity>
+
+			<View className='w-[1px] h-[20px] bg-[#E5E5E5]' />
+
+			{/* 🔹 Clases */}
+			<TouchableOpacity
+				onPress={() => onChange('clases')}
+				className={`flex-1 py-2 rounded-xl ${
+					activeTab === 'clases' ? 'bg-white dark:bg-neutral-800' : ''
+				}`}>
+				<Text className={getTextStyle('clases')}>Clases</Text>
+			</TouchableOpacity>
+
+			<View className='w-[1px] h-[20px] bg-[#E5E5E5]' />
+
+			{/* 🔹 Mensajes */}
+			<TouchableOpacity
+				onPress={() => onChange('mensajes')}
+				className={`flex-1 py-2 rounded-xl ${
+					activeTab === 'mensajes' ? 'bg-white dark:bg-neutral-800' : ''
+				}`}>
+				<Text className={getTextStyle('mensajes')}>Mensajes</Text>
+			</TouchableOpacity>
+		</View>
+	);
+}

--- a/components/auth/dashboard/InstructorTabs.tsx
+++ b/components/auth/dashboard/InstructorTabs.tsx
@@ -16,7 +16,6 @@ export function InstructorTabs({ activeTab, onChange }: Props) {
 
 	return (
 		<View className='flex-row justify-between items-center bg-[#F8F9FB] dark:bg-neutral-900 rounded-2xl px-2 py-2 mt-6'>
-			{/* 🔹 Clientes */}
 			<TouchableOpacity
 				onPress={() => onChange('clientes')}
 				className={`flex-1 py-2 rounded-xl ${
@@ -27,7 +26,6 @@ export function InstructorTabs({ activeTab, onChange }: Props) {
 
 			<View className='w-[1px] h-[20px] bg-[#E5E5E5]' />
 
-			{/* 🔹 Clases */}
 			<TouchableOpacity
 				onPress={() => onChange('clases')}
 				className={`flex-1 py-2 rounded-xl ${
@@ -38,7 +36,6 @@ export function InstructorTabs({ activeTab, onChange }: Props) {
 
 			<View className='w-[1px] h-[20px] bg-[#E5E5E5]' />
 
-			{/* 🔹 Mensajes */}
 			<TouchableOpacity
 				onPress={() => onChange('mensajes')}
 				className={`flex-1 py-2 rounded-xl ${

--- a/components/auth/dashboard/MyClientsCardGroup.tsx
+++ b/components/auth/dashboard/MyClientsCardGroup.tsx
@@ -9,7 +9,7 @@ export function MyClientsCardGroup() {
 			name: 'Juan Perez',
 			level: 'Nivel 5',
 			program: 'Fuerza Máxima - Semana 2',
-			avatar: null, // Podrías usar URL real más adelante
+			avatar: null,
 		},
 		{
 			id: 2,
@@ -22,24 +22,20 @@ export function MyClientsCardGroup() {
 
 	return (
 		<View className='mt-6'>
-			{/* 🧭 Header */}
 			<View className='flex-row items-center mb-3'>
 				<CalendarDaysIcon size={18} color='#000000' />
 				<Text className='ml-2 text-[16px] font-medium text-[#000000]'>Mis Clientes</Text>
 			</View>
 
-			{/* 👥 Lista de clientes */}
 			{clients.map((client) => (
 				<TouchableOpacity
 					key={client.id}
 					className='flex-row items-center justify-between bg-[#F8F9FB] rounded-2xl px-4 py-3 mb-3'
 					activeOpacity={0.8}>
-					{/* Avatar */}
 					<View className='w-10 h-10 rounded-full bg-[#CFE4FF] justify-center items-center mr-3'>
 						<UserCircleIcon size={24} color='#62A3FF' />
 					</View>
 
-					{/* Info del cliente */}
 					<View className='flex-1'>
 						<Text className='text-[14px] font-bold text-[#1F2024]'>{client.name}</Text>
 						<Text className='text-[12px] text-[#71727A]'>{client.level}</Text>
@@ -48,7 +44,6 @@ export function MyClientsCardGroup() {
 						</Text>
 					</View>
 
-					{/* Flecha */}
 					<ChevronRightIcon size={12} color='#71727A' />
 				</TouchableOpacity>
 			))}

--- a/components/auth/dashboard/MyClientsCardGroup.tsx
+++ b/components/auth/dashboard/MyClientsCardGroup.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import { CalendarDaysIcon, ChevronRightIcon, UserCircleIcon } from 'react-native-heroicons/outline';
+
+export function MyClientsCardGroup() {
+	const clients = [
+		{
+			id: 1,
+			name: 'Juan Perez',
+			level: 'Nivel 5',
+			program: 'Fuerza Máxima - Semana 2',
+			avatar: null, // Podrías usar URL real más adelante
+		},
+		{
+			id: 2,
+			name: 'Juan Perez',
+			level: 'Nivel 5',
+			program: 'Fuerza Máxima - Semana 2',
+			avatar: null,
+		},
+	];
+
+	return (
+		<View className='mt-6'>
+			{/* 🧭 Header */}
+			<View className='flex-row items-center mb-3'>
+				<CalendarDaysIcon size={18} color='#000000' />
+				<Text className='ml-2 text-[16px] font-medium text-[#000000]'>Mis Clientes</Text>
+			</View>
+
+			{/* 👥 Lista de clientes */}
+			{clients.map((client) => (
+				<TouchableOpacity
+					key={client.id}
+					className='flex-row items-center justify-between bg-[#F8F9FB] rounded-2xl px-4 py-3 mb-3'
+					activeOpacity={0.8}>
+					{/* Avatar */}
+					<View className='w-10 h-10 rounded-full bg-[#CFE4FF] justify-center items-center mr-3'>
+						<UserCircleIcon size={24} color='#62A3FF' />
+					</View>
+
+					{/* Info del cliente */}
+					<View className='flex-1'>
+						<Text className='text-[14px] font-bold text-[#1F2024]'>{client.name}</Text>
+						<Text className='text-[12px] text-[#71727A]'>{client.level}</Text>
+						<Text className='text-[16px] font-medium text-[#000000] mt-0.5'>
+							{client.program}
+						</Text>
+					</View>
+
+					{/* Flecha */}
+					<ChevronRightIcon size={12} color='#71727A' />
+				</TouchableOpacity>
+			))}
+		</View>
+	);
+}

--- a/components/auth/dashboard/QRModal.tsx
+++ b/components/auth/dashboard/QRModal.tsx
@@ -12,7 +12,6 @@ interface QRModalProps {
 export const QRModal: React.FC<QRModalProps> = ({ visible, onClose, token }) => {
 	return (
 		<Modal animationType='fade' transparent={true} visible={visible} onRequestClose={onClose}>
-			{/* Overlay con backdrop */}
 			<TouchableOpacity
 				style={{
 					flex: 1,
@@ -23,7 +22,6 @@ export const QRModal: React.FC<QRModalProps> = ({ visible, onClose, token }) => 
 				}}
 				activeOpacity={1}
 				onPress={onClose}>
-				{/* Modal Container */}
 				<TouchableOpacity
 					style={{
 						backgroundColor: 'white',
@@ -39,7 +37,6 @@ export const QRModal: React.FC<QRModalProps> = ({ visible, onClose, token }) => 
 					}}
 					activeOpacity={1}
 					onPress={(e) => e.stopPropagation()}>
-					{/* Close Button */}
 					<TouchableOpacity
 						onPress={onClose}
 						style={{
@@ -55,7 +52,6 @@ export const QRModal: React.FC<QRModalProps> = ({ visible, onClose, token }) => 
 						<XMarkIcon size={20} color='#666' />
 					</TouchableOpacity>
 
-					{/* Title */}
 					<Text
 						style={{
 							fontSize: 20,
@@ -69,7 +65,6 @@ export const QRModal: React.FC<QRModalProps> = ({ visible, onClose, token }) => 
 						Código QR de Acceso
 					</Text>
 
-					{/* QR Code Container */}
 					<View
 						style={{
 							backgroundColor: 'white',
@@ -97,7 +92,6 @@ export const QRModal: React.FC<QRModalProps> = ({ visible, onClose, token }) => 
 						/>
 					</View>
 
-					{/* Subtitle */}
 					<Text
 						style={{
 							fontSize: 14,

--- a/components/auth/dashboard/RecepcionistStatsCardGroup.tsx
+++ b/components/auth/dashboard/RecepcionistStatsCardGroup.tsx
@@ -3,12 +3,12 @@ import React from 'react';
 import { Text, View } from 'react-native';
 import { CalendarDaysIcon, CheckCircleIcon } from 'react-native-heroicons/mini';
 
-export function InstructorStatsCardGroup() {
+export function RecepcionistStatsCardGroup() {
 	return (
 		<View className='flex flex-wrap flex-row justify-between px-2 mt-4'>
 			<View className='w-[48%] bg-white dark:bg-neutral-900 rounded-2xl p-4 mb-4 shadow-sm border border-neutral-200 dark:border-neutral-800'>
 				<View className='flex-row items-center justify-center mb-1'>
-					<CheckCircleIcon width={20} height={20} color='#22C55E' />
+					<CheckCircleIcon width={24} height={24} color='#22C55E' />
 					<Text className='ml-1 text-[16px] font-medium text-neutral-900 dark:text-white text-center'>
 						Check-ins Mensual
 					</Text>
@@ -20,9 +20,9 @@ export function InstructorStatsCardGroup() {
 
 			<View className='w-[48%] bg-white dark:bg-neutral-900 rounded-2xl p-4 mb-4 shadow-sm border border-neutral-200 dark:border-neutral-800'>
 				<View className='flex-row items-center justify-center mb-1'>
-					<CalendarDaysIcon width={19.2} height={19.2} color='#F17B23' />
+					<CalendarDaysIcon width={24} height={24} color='#F17B23' />
 					<Text className='ml-1 text-[16px] font-medium text-neutral-900 dark:text-white text-center'>
-						Clases Esta Semana
+						Clases Hoy
 					</Text>
 				</View>
 				<Text className='text-center text-[24px] font-semibold text-neutral-900 dark:text-white mt-1'>
@@ -34,7 +34,7 @@ export function InstructorStatsCardGroup() {
 				<View className='flex-row items-center justify-center mb-1'>
 					<Profile2User size={24} color='#9747FF' variant='Bold' />
 					<Text className='ml-1 text-[16px] font-medium text-neutral-900 dark:text-white text-center'>
-						Mensajes Nuevos
+						Aforo Actual
 					</Text>
 				</View>
 				<Text className='text-center text-[24px] font-semibold text-neutral-900 dark:text-white mt-1'>
@@ -46,7 +46,7 @@ export function InstructorStatsCardGroup() {
 				<View className='flex-row items-center justify-center mb-1'>
 					<Flag2 size={24} color='#E1491B' variant='Bold' />
 					<Text className='ml-1 text-[16px] font-medium text-neutral-900 dark:text-white text-center'>
-						Rutinas Asignadas
+						vs Ayer
 					</Text>
 				</View>
 				<Text className='text-center text-[24px] font-semibold text-neutral-900 dark:text-white mt-1'>

--- a/components/auth/dashboard/RecepcionistTodayClassCard.tsx
+++ b/components/auth/dashboard/RecepcionistTodayClassCard.tsx
@@ -1,0 +1,80 @@
+import { Dumbbell } from 'lucide-react-native';
+import React from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import { CheckCircleIcon, ClockIcon, UserIcon, UsersIcon } from 'react-native-heroicons/mini';
+
+export function RecepcionistTodayClassCard() {
+	return (
+		<View className='bg-white dark:bg-neutral-900 rounded-2xl border border-[#BBBBBB] p-4 mt-4'>
+			<View className='flex-row items-center mb-3'>
+				<CheckCircleIcon width={16} height={16} color='#0F172A' />
+				<Text className='ml-2 text-[16px] font-semibold text-neutral-900 dark:text-white'>
+					Clases de Hoy
+				</Text>
+			</View>
+
+			<Text className='text-[14px] text-neutral-700 dark:text-neutral-400 mb-4'>
+				Horario y asistencia
+			</Text>
+
+			{[1, 2].map((_, index) => (
+				<View
+					key={index}
+					className='border border-[#BBBBBB] rounded-xl mb-4 p-4 bg-white dark:bg-neutral-800'>
+					<View className='flex-row justify-between items-start mb-3'>
+						<View className='flex-row items-center'>
+							<View className='bg-[#F2F4F5] rounded-md p-2 mr-2'>
+								<Dumbbell width={35} height={35} color='#F27F2A' />
+							</View>
+							<View>
+								<Text className='text-[16px] font-extrabold text-neutral-900 dark:text-white leading-tight'>
+									POWERLIFTING
+								</Text>
+								<Text className='text-[16px] font-extrabold text-[#F27F2A] leading-tight'>
+									AVANZADO
+								</Text>
+							</View>
+						</View>
+
+						<View className='border border-[#0F172A] rounded-full px-3 py-1'>
+							<Text className='text-[12px] font-semibold text-[#0F172A]'>
+								EN CURSO
+							</Text>
+						</View>
+					</View>
+
+					<View className='gap-2 mb-3'>
+						<View className='flex-row items-center'>
+							<UserIcon width={14} height={14} color='#0F172A' />
+							<Text className='ml-2 text-[14px] text-neutral-800 dark:text-neutral-300'>
+								CARLOS RUÍZ
+							</Text>
+						</View>
+
+						<View className='flex-row items-center'>
+							<ClockIcon width={16} height={16} color='#0F172A' />
+							<Text className='ml-2 text-[14px] text-neutral-800 dark:text-neutral-300'>
+								07:00 (90 MIN)
+							</Text>
+						</View>
+
+						<View className='flex-row items-center'>
+							<UsersIcon width={17} height={16} color='#0F172A' />
+							<Text className='ml-2 text-[14px] text-neutral-800 dark:text-neutral-300'>
+								8/121 INSCRITOS
+							</Text>
+						</View>
+					</View>
+
+					<TouchableOpacity
+						activeOpacity={0.8}
+						className='border border-[#F27F2A] rounded-xl py-2 mt-1'>
+						<Text className='text-center text-[#F27F2A] font-medium text-[14px]'>
+							Ver detalles
+						</Text>
+					</TouchableOpacity>
+				</View>
+			))}
+		</View>
+	);
+}

--- a/components/auth/dashboard/TodayClassCard.tsx
+++ b/components/auth/dashboard/TodayClassCard.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import { CalendarDaysIcon, ChevronRightIcon, ClockIcon } from 'react-native-heroicons/mini';
+
+export function TodayClassCard() {
+	return (
+		<View className='bg-white dark:bg-neutral-900 rounded-2xl p-4 mt-6 shadow-sm border border-neutral-200 dark:border-neutral-800'>
+			<View className='flex-row items-center mb-2'>
+				<CalendarDaysIcon width={20} height={20} color='#000000' />
+				<Text className='ml-2 text-[16px] font-medium text-black dark:text-white'>
+					Clase de hoy
+				</Text>
+			</View>
+
+			<View className='bg-[#FFFFFF] dark:bg-neutral-800 rounded-xl p-4 flex-row justify-between items-center'>
+				<View className='flex-col'>
+					<Text className='text-[14px] font-bold text-[#1F2024] dark:text-white'>
+						Powerlifting Avanzado
+					</Text>
+					<Text className='text-[12px] text-[#71727A] mt-[2px]'>
+						15 de Noviembre del 2025
+					</Text>
+
+					<View className='flex-row items-center mt-2'>
+						<ClockIcon width={14} height={14} color='#000000' />
+						<Text className='ml-1 text-[10px] font-semibold uppercase tracking-[0.05em] text-black dark:text-white'>
+							07:00 (90 MIN)
+						</Text>
+					</View>
+				</View>
+
+				<TouchableOpacity className='flex-row items-center bg-white dark:bg-neutral-900 rounded-lg px-3 py-1 border border-[#E5E5E5] dark:border-neutral-700'>
+					<Text className='text-[12px] font-medium text-[#000] dark:text-white'>
+						10/15
+					</Text>
+					<ChevronRightIcon
+						width={12}
+						height={12}
+						color='#71727A'
+						style={{ marginLeft: 4 }}
+					/>
+				</TouchableOpacity>
+			</View>
+		</View>
+	);
+}

--- a/components/auth/dashboard/ValidateCheckInCard.tsx
+++ b/components/auth/dashboard/ValidateCheckInCard.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { CheckCircleIcon, MagnifyingGlassIcon, QrCodeIcon } from 'react-native-heroicons/mini';
+
+export function ValidateCheckInCard() {
+	return (
+		<View className='bg-white dark:bg-neutral-900 rounded-2xl p-4 mt-4 shadow-sm border border-neutral-200 dark:border-neutral-800'>
+			<View className='flex-row items-center mb-3'>
+				<CheckCircleIcon width={20} height={20} color='#0F172A' />
+				<Text className='ml-2 text-[16px] font-semibold text-neutral-900 dark:text-white'>
+					Validar Check-in
+				</Text>
+			</View>
+
+			<View className='flex-row items-center border border-neutral-300 dark:border-neutral-700 rounded-xl px-3 py-2 mb-3'>
+				<MagnifyingGlassIcon width={18} height={18} color='#0F172A' />
+				<TextInput
+					placeholder='Buscar por documento de identidad'
+					placeholderTextColor='#71727A'
+					className='ml-2 flex-1 text-[15px] text-neutral-900 dark:text-white'
+				/>
+			</View>
+
+			<TouchableOpacity
+				activeOpacity={0.8}
+				className='flex-row items-center justify-center border border-neutral-300 dark:border-neutral-700 rounded-xl px-3 py-2'>
+				<QrCodeIcon width={16} height={16} color='#0F172A' />
+				<Text className='ml-2 text-[15px] font-medium text-neutral-900 dark:text-white'>
+					Escanear QR
+				</Text>
+			</TouchableOpacity>
+		</View>
+	);
+}

--- a/components/auth/dashboard/membershipcard.tsx
+++ b/components/auth/dashboard/membershipcard.tsx
@@ -5,7 +5,7 @@ import { QrCodeIcon } from 'react-native-heroicons/outline';
 
 interface Props {
 	daysRemaining: number;
-	onQRPress: () => void; // 👈 Nueva prop para abrir el modal
+	onQRPress: () => void;
 }
 
 export const MembershipCard: React.FC<Props> = ({ daysRemaining, onQRPress }) => {
@@ -19,24 +19,20 @@ export const MembershipCard: React.FC<Props> = ({ daysRemaining, onQRPress }) =>
 			start={{ x: 0, y: 0.1 }}
 			end={{ x: 1, y: 0.2 }}
 			style={[styles.card, { width: cardWidth }]}>
-			{/* Contenido principal - AHORA ES TOUCHABLE */}
 			<TouchableOpacity
 				style={styles.contentContainer}
 				onPress={onQRPress}
 				activeOpacity={0.8}>
-				{/* Icono QR */}
 				<View style={styles.iconContainer}>
 					<QrCodeIcon size={56} color='#FFFFFF' strokeWidth={0.5} />
 				</View>
 
-				{/* Texto derecho */}
 				<View style={styles.textContainer}>
 					<Text style={styles.title}>Acceso al Gimnasio</Text>
 					<Text style={styles.subtitle}>Escanea para ingresar</Text>
 				</View>
 			</TouchableOpacity>
 
-			{/* Texto inferior */}
 			<Text style={styles.footerText}>Membresía activa: {daysRemaining} días restantes</Text>
 		</LinearGradient>
 	);

--- a/components/auth/dashboard/progresscard.tsx
+++ b/components/auth/dashboard/progresscard.tsx
@@ -3,26 +3,23 @@ import { Dimensions, StyleSheet, Text, View } from 'react-native';
 import { CalendarDaysIcon } from 'react-native-heroicons/mini';
 
 interface Props {
-	weekProgress: number; // valor entre 0 y 1
+	weekProgress: number;
 	calories: number;
-	completed: string; // ejemplo: "4/5"
+	completed: string;
 }
 
 export const ProgressCard: React.FC<Props> = ({ weekProgress, calories, completed }) => {
 	const { width } = Dimensions.get('window');
-	const cardWidth = Math.min(width - 32, 380); // responsive máx 380px
+	const cardWidth = Math.min(width - 32, 380);
 
 	return (
 		<View style={[styles.container, { width: cardWidth }]}>
-			{/* Encabezado */}
 			<View style={styles.header}>
 				<Text style={styles.title}>TU PROGRESO</Text>
 				<Text style={styles.link}>VER MÁS</Text>
 			</View>
 
-			{/* Cajas de progreso */}
 			<View style={styles.cardsContainer}>
-				{/* Card: Esta semana */}
 				<View style={styles.card}>
 					<View style={styles.cardHeader}>
 						<Text style={styles.cardTitle}>ESTA SEMANA</Text>
@@ -36,7 +33,6 @@ export const ProgressCard: React.FC<Props> = ({ weekProgress, calories, complete
 					</View>
 				</View>
 
-				{/* Card: Calorías */}
 				<View style={styles.card}>
 					<Text style={styles.cardTitle}>CALORÍAS ESTIMADAS</Text>
 					<Text style={styles.cardValue}>{calories}</Text>
@@ -86,12 +82,11 @@ const styles = StyleSheet.create({
 		borderRadius: 8,
 		padding: 12,
 		justifyContent: 'space-between',
-		// 🔥 sombra sutil como Figma
 		shadowColor: '#000',
 		shadowOffset: { width: 0, height: 1 },
 		shadowOpacity: 0.1,
 		shadowRadius: 3,
-		elevation: 1, // para Android
+		elevation: 1,
 	},
 	cardHeader: {
 		flexDirection: 'row',

--- a/components/auth/dashboard/reservedclasses.tsx
+++ b/components/auth/dashboard/reservedclasses.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 export const ReservedClassesCard: React.FC<Props> = ({ reserved }) => {
 	const { width } = Dimensions.get('window');
-	const cardWidth = Math.min(width - 32, 382); // 🔥 mismo ancho que las demás secciones
+	const cardWidth = Math.min(width - 32, 382);
 
 	return (
 		<View style={[styles.card, { width: cardWidth }]}>
@@ -28,7 +28,7 @@ const styles = StyleSheet.create({
 		alignItems: 'center',
 		padding: 12,
 		height: 91,
-		// 🔥 sombra sutil como en el Figma
+
 		shadowColor: '#000000',
 		shadowOffset: { width: 0, height: 1 },
 		shadowOpacity: 0.1,

--- a/components/auth/dashboard/todayroutinecard.tsx
+++ b/components/auth/dashboard/todayroutinecard.tsx
@@ -10,22 +10,19 @@ interface Props {
 
 export const TodayRoutineCard: React.FC<Props> = ({ title, time, date }) => {
 	const { width } = Dimensions.get('window');
-	const cardWidth = Math.min(width - 32, 372); // según Figma
+	const cardWidth = Math.min(width - 32, 372);
 
 	return (
 		<View style={[styles.container, { width: cardWidth }]}>
-			{/* Header */}
 			<View style={styles.header}>
 				<Text style={styles.title}>Mi rutina de hoy</Text>
 				<Text style={styles.date}>{date}</Text>
 			</View>
 
-			{/* Imagen con overlay */}
 			<ImageBackground
 				source={require('@/assets/images/rutina.png')}
 				style={styles.image}
 				imageStyle={styles.imageRadius}>
-				{/* Overlay oscuro sutil */}
 				<LinearGradient
 					colors={['rgba(17,17,18,0.2)', 'rgba(17,17,18,0.6)']}
 					start={{ x: 0, y: 0.2 }}
@@ -33,7 +30,6 @@ export const TodayRoutineCard: React.FC<Props> = ({ title, time, date }) => {
 					style={styles.overlay}
 				/>
 
-				{/* Texto dentro de la imagen */}
 				<View style={styles.textContainer}>
 					<Text style={styles.imageTitle}>{title}</Text>
 					<Text style={styles.imageSubtitle}>{time}</Text>

--- a/components/auth/dashboard/userheader.tsx
+++ b/components/auth/dashboard/userheader.tsx
@@ -28,7 +28,6 @@ export const UserHeader: React.FC<Props> = ({
 
 	return (
 		<View className='mb-6 relative'>
-			{/* Cabecera */}
 			<View className='flex-row justify-between items-center'>
 				<View className='flex-row items-center'>
 					<Image
@@ -66,7 +65,6 @@ export const UserHeader: React.FC<Props> = ({
 					</View>
 				</View>
 
-				{/* Botón campana */}
 				<View className='relative'>
 					<TouchableOpacity
 						onPress={() => setShowNotifications(!showNotifications)}
@@ -81,7 +79,6 @@ export const UserHeader: React.FC<Props> = ({
 				</View>
 			</View>
 
-			{/* Panel flotante de notificaciones */}
 			{showNotifications && (
 				<View className='absolute right-0 top-16 bg-white dark:bg-neutral-900 border border-gray-200 dark:border-neutral-700 rounded-2xl shadow-lg p-3 w-72 z-50'>
 					<Text className='text-base font-semibold mb-2'>Notificaciones</Text>

--- a/components/auth/dashboard/weekcalendar.tsx
+++ b/components/auth/dashboard/weekcalendar.tsx
@@ -18,7 +18,6 @@ interface WeekCalendarProps {
 	initialDate?: string;
 }
 
-// Definimos la constante con el tipo correcto para que TypeScript no se queje
 const EMPTY_MARKED_DATES: { [date: string]: { marked?: boolean; dotColor?: string } } = {};
 
 export const WeekCalendar: React.FC<WeekCalendarProps> = ({
@@ -31,14 +30,12 @@ export const WeekCalendar: React.FC<WeekCalendarProps> = ({
 	);
 	const [weekDays, setWeekDays] = useState<DayData[]>([]);
 
-	// Generar días de la semana actual basado en la fecha de hoy
 	useEffect(() => {
 		const generateWeekDays = () => {
 			const today = new Date();
-			const currentDay = today.getDay(); // 0 = Sunday, 1 = Monday, etc.
+			const currentDay = today.getDay();
 			const monday = new Date(today);
 
-			// Ajustar al lunes de la semana actual
 			const diff = currentDay === 0 ? -6 : 1 - currentDay;
 			monday.setDate(today.getDate() + diff);
 
@@ -70,7 +67,6 @@ export const WeekCalendar: React.FC<WeekCalendarProps> = ({
 	const handleDayPress = (day: DayData) => {
 		setSelectedDateString(day.dateString);
 
-		// Crear objeto DateData compatible con react-native-calendars
 		const dateData: DateData = {
 			dateString: day.dateString,
 			day: day.date,

--- a/components/auth/home/BackgroundCarousel.tsx
+++ b/components/auth/home/BackgroundCarousel.tsx
@@ -49,7 +49,7 @@ export default function BackgroundCarousel({ images, onIndexChange, interval = 3
 	return (
 		<FlatList
 			ref={flatListRef}
-			style={{ flex: 1 }} // 👈 ocupa toda la pantalla
+			style={{ flex: 1 }}
 			data={images}
 			keyExtractor={(_, i) => String(i)}
 			horizontal
@@ -63,10 +63,10 @@ export default function BackgroundCarousel({ images, onIndexChange, interval = 3
 					<Image
 						source={item}
 						style={{
-							width: width * 1, // zoom in
-							height: height * 1, // zoom in
+							width: width * 1,
+							height: height * 1,
 							position: 'absolute',
-							top: '-5%', // 👈 centra el zoom
+							top: '-5%',
 						}}
 						resizeMode='cover'
 					/>

--- a/components/auth/home/SignInButton.tsx
+++ b/components/auth/home/SignInButton.tsx
@@ -26,12 +26,7 @@ export function SignInButton({
 			disabled={disabled}
 			onPressIn={() => setPressed(true)}
 			onPressOut={() => setPressed(false)}
-			style={[
-				styles.base,
-				styles.outline,
-				containerStyle,
-				pressed && styles.pressed, // 🔑 aplica color si está presionado
-			]}>
+			style={[styles.base, styles.outline, containerStyle, pressed && styles.pressed]}>
 			<Text style={[styles.text, styles.textOutline, textStyle]}>{label}</Text>
 		</TouchableOpacity>
 	);
@@ -57,7 +52,7 @@ const styles = StyleSheet.create({
 		borderColor: '#D2D2D2',
 	},
 	pressed: {
-		backgroundColor: 'rgba(255,255,255,0.2)', // 🔑 cambia color al tocar
+		backgroundColor: 'rgba(255,255,255,0.2)',
 	},
 	text: {
 		color: '#FFFFFF',

--- a/components/auth/home/SignUpButton.tsx
+++ b/components/auth/home/SignUpButton.tsx
@@ -48,7 +48,7 @@ const styles = StyleSheet.create({
 	text: {
 		color: '#FFFFFF',
 		fontSize: 25,
-		lineHeight: BUTTON_H - PADDING_V * 2, // 30
+		lineHeight: BUTTON_H - PADDING_V * 2,
 		fontFamily: 'Montserrat_500Medium',
 		textAlign: 'center',
 		includeFontPadding: false,

--- a/components/auth/register/Step2Credentials.tsx
+++ b/components/auth/register/Step2Credentials.tsx
@@ -1,6 +1,5 @@
-// components/auth/register/Step2Credentials.tsx
 import { Colors } from '@/constants/theme';
-import { RegisterData } from '@/schemas/register'; // Asegúrate de importar esto
+import { RegisterData } from '@/schemas/register';
 import { SlidersVertical } from 'lucide-react-native';
 import { Control, Controller, FieldErrors } from 'react-hook-form';
 import { PrimaryButton } from '../../PrimaryButton';
@@ -39,7 +38,7 @@ export function Step2Credentials({ control, errors, onNextStep }: Props) {
 						onChangeText={onChange}
 						value={value}
 						error={errors.password?.message}
-						isPasswordInput // Activa el ícono del ojo
+						isPasswordInput
 						icon={<SlidersVertical size={16} color={Colors.light.icon} />}
 					/>
 				)}
@@ -54,7 +53,7 @@ export function Step2Credentials({ control, errors, onNextStep }: Props) {
 						onChangeText={onChange}
 						value={value}
 						error={errors.confirmPassword?.message}
-						isPasswordInput // Activa el ícono del ojo
+						isPasswordInput
 						icon={<SlidersVertical size={16} color={Colors.light.icon} />}
 					/>
 				)}

--- a/components/auth/register/Step3PersonalDetails.tsx
+++ b/components/auth/register/Step3PersonalDetails.tsx
@@ -69,7 +69,6 @@ export function Step3PersonalDetails({ control, errors, onSubmit }: Props) {
 				)}
 			/>
 
-			{/* Campo con DateTimePicker para fecha de nacimiento */}
 			<Controller
 				control={control}
 				name='birthDate'
@@ -115,7 +114,6 @@ export function Step3PersonalDetails({ control, errors, onSubmit }: Props) {
 				}}
 			/>
 
-			{/* Campo de teléfono internacional */}
 			<Controller
 				control={control}
 				name='phone'

--- a/components/external-link.tsx
+++ b/components/external-link.tsx
@@ -12,9 +12,7 @@ export function ExternalLink({ href, ...rest }: Props) {
 			href={href}
 			onPress={async (event) => {
 				if (process.env.EXPO_OS !== 'web') {
-					// Prevent the default behavior of linking to the default browser on native.
 					event.preventDefault();
-					// Open the link in an in-app browser.
 					await openBrowserAsync(href, {
 						presentationStyle: WebBrowserPresentationStyle.AUTOMATIC,
 					});

--- a/components/haptic-tab.tsx
+++ b/components/haptic-tab.tsx
@@ -8,7 +8,6 @@ export function HapticTab(props: BottomTabBarButtonProps) {
 			{...props}
 			onPressIn={(ev) => {
 				if (process.env.EXPO_OS === 'ios') {
-					// Add a soft haptic feedback when pressing down on the tabs.
 					Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
 				}
 				props.onPressIn?.(ev);

--- a/components/themed-text.tsx
+++ b/components/themed-text.tsx
@@ -1,8 +1,6 @@
-// components/themed-text.tsx
-
 import { StyleSheet, Text, type TextProps } from 'react-native';
 
-import { Fonts } from '@/constants/theme'; // Importa las fuentes
+import { Fonts } from '@/constants/theme';
 import { useThemeColor } from '@/hooks/use-theme-color';
 
 export type ThemedTextProps = TextProps & {
@@ -20,7 +18,6 @@ export function ThemedText({
 }: ThemedTextProps) {
 	const color = useThemeColor({ light: lightColor, dark: darkColor }, 'text');
 
-	// Determina la familia de fuente según el tipo
 	const fontFamily =
 		type === 'title'
 			? Fonts.title
@@ -31,7 +28,7 @@ export function ThemedText({
 	return (
 		<Text
 			style={[
-				{ color, fontFamily }, // Aplica el color y la fuente
+				{ color, fontFamily },
 				type === 'default' ? styles.default : undefined,
 				type === 'title' ? styles.title : undefined,
 				type === 'defaultSemiBold' ? styles.defaultSemiBold : undefined,
@@ -54,7 +51,7 @@ const styles = StyleSheet.create({
 		lineHeight: 24,
 	},
 	title: {
-		fontSize: 42, // Ajusta el tamaño para Bebas Neue
+		fontSize: 42,
 		lineHeight: 42,
 	},
 	subtitle: {

--- a/components/ui/icon-symbol.tsx
+++ b/components/ui/icon-symbol.tsx
@@ -1,18 +1,11 @@
-// Fallback for using MaterialIcons on Android and web.
-
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import { SymbolWeight, SymbolViewProps } from 'expo-symbols';
+import { SymbolViewProps, SymbolWeight } from 'expo-symbols';
 import { ComponentProps } from 'react';
 import { OpaqueColorValue, type StyleProp, type TextStyle } from 'react-native';
 
 type IconMapping = Record<SymbolViewProps['name'], ComponentProps<typeof MaterialIcons>['name']>;
 type IconSymbolName = keyof typeof MAPPING;
 
-/**
- * Add your SF Symbols to Material Icons mappings here.
- * - see Material Icons in the [Icons Directory](https://icons.expo.fyi).
- * - see SF Symbols in the [SF Symbols](https://developer.apple.com/sf-symbols/) app.
- */
 const MAPPING = {
 	'house.fill': 'home',
 	'paperplane.fill': 'send',
@@ -20,11 +13,6 @@ const MAPPING = {
 	'chevron.right': 'chevron-right',
 } as IconMapping;
 
-/**
- * An icon component that uses native SF Symbols on iOS, and Material Icons on Android and web.
- * This ensures a consistent look across platforms, and optimal resource usage.
- * Icon `name`s are based on SF Symbols and require manual mapping to Material Icons.
- */
 export function IconSymbol({
 	name,
 	size = 24,

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -1,4 +1,3 @@
-// --- Nueva Paleta de Colores VitalFit ---
 const naranjaVital = '#F27F2A';
 const negroCarbon = '#1A1A1A';
 const grisOscuro = '#5C5E60';
@@ -8,21 +7,21 @@ const rojoIntenso = '#EA232D';
 export const Colors = {
 	light: {
 		text: negroCarbon,
-		background: '#FFFFFF', // Fondo blanco para el tema claro
+		background: '#FFFFFF',
 		tint: naranjaVital,
 		icon: grisOscuro,
 		tabIconDefault: grisOscuro,
 		tabIconSelected: naranjaVital,
 	},
 	dark: {
-		text: '#FFFFFF', // Texto blanco para el tema oscuro
+		text: '#FFFFFF',
 		background: negroCarbon,
 		tint: naranjaVital,
 		icon: grisOscuro,
 		tabIconDefault: grisOscuro,
 		tabIconSelected: naranjaVital,
 	},
-	// Colores adicionales para uso específico
+
 	accent: {
 		green: verdeVital,
 		red: rojoIntenso,
@@ -32,6 +31,6 @@ export const Colors = {
 export const Fonts = {
 	title: 'BebasNeue-Regular',
 	subtitle: 'Montserrat-ExtraBold',
-	medium: 'Montserrat_500Medium', // Añadido para el estilo de texto mediano
-	default: 'Montserrat-ExtraBold', // Usamos Montserrat como fuente por defecto para el resto del texto
+	medium: 'Montserrat_500Medium',
+	default: 'Montserrat-ExtraBold',
 };

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -7,7 +7,6 @@ import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig([
-
 	js.configs.recommended,
 
 	...tseslint.configs.recommended,
@@ -22,7 +21,7 @@ export default defineConfig([
 			globals: { ...globals.browser, ...globals.node },
 		},
 		plugins: {
-			'react-hooks': reactHooks, 
+			'react-hooks': reactHooks,
 		},
 		rules: {
 			'react/react-in-jsx-scope': 'off',
@@ -45,11 +44,9 @@ export default defineConfig([
 		},
 	},
 
-
 	{
 		ignores: ['node_modules', 'dist', 'build', 'android', 'ios', '.expo', '.prettierrc.js'],
 	},
-
 
 	prettier,
 ]);

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -1,6 +1,5 @@
-// eslint.config.mts
 import js from '@eslint/js';
-import prettier from 'eslint-config-prettier'; // flat-config compatible
+import prettier from 'eslint-config-prettier';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 import { defineConfig } from 'eslint/config';
@@ -8,38 +7,31 @@ import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig([
-	// Base JS
+
 	js.configs.recommended,
 
-	// TypeScript (flat configs ya traen parser y reglas base)
 	...tseslint.configs.recommended,
 
-	// React
 	react.configs.flat.recommended,
 
-	// Detectar versión de React
 	{ settings: { react: { version: 'detect' } } },
 
-	// TS y TSX (código de app)
 	{
 		files: ['**/*.{ts,tsx}'],
 		languageOptions: {
 			globals: { ...globals.browser, ...globals.node },
 		},
 		plugins: {
-			'react-hooks': reactHooks, // <-- registrar plugin
+			'react-hooks': reactHooks, 
 		},
 		rules: {
 			'react/react-in-jsx-scope': 'off',
-			// En RN se usa `require()` para imágenes
 			'@typescript-eslint/no-require-imports': 'off',
-			// Reglas de hooks
 			'react-hooks/rules-of-hooks': 'error',
 			'react-hooks/exhaustive-deps': 'warn',
 		},
 	},
 
-	// JS de Node / Metro / scripts: permitir require y console
 	{
 		files: ['*.js', 'metro.config.js', 'remove_console.js', 'scripts/**/*.js'],
 		languageOptions: {
@@ -53,11 +45,11 @@ export default defineConfig([
 		},
 	},
 
-	// Ignorados
+
 	{
 		ignores: ['node_modules', 'dist', 'build', 'android', 'ios', '.expo', '.prettierrc.js'],
 	},
 
-	// Siempre al final: desactiva reglas que choquen con Prettier
+
 	prettier,
 ]);

--- a/hooks/use-color-scheme.web.ts
+++ b/hooks/use-color-scheme.web.ts
@@ -1,9 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useColorScheme as useRNColorScheme } from 'react-native';
 
-/**
- * To support static rendering, this value needs to be re-calculated on the client side for web
- */
 export function useColorScheme() {
 	const [hasHydrated, setHasHydrated] = useState(false);
 

--- a/hooks/use-theme-color.ts
+++ b/hooks/use-theme-color.ts
@@ -1,8 +1,3 @@
-/**
- * Learn more about light and dark modes:
- * https://docs.expo.dev/guides/color-schemes/
- */
-
 import { Colors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
 	preset: 'jest-expo',
-	setupFilesAfterEnv: [], // Dejamos esto vacío a propósito
+	setupFilesAfterEnv: [],
 	transformIgnorePatterns: [
 		'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)',
 	],

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
 				"expo-symbols": "~1.0.7",
 				"expo-system-ui": "~6.0.8",
 				"expo-web-browser": "~15.0.8",
+				"iconsax-react-native": "^0.0.8",
 				"lucide-react-native": "^0.544.0",
 				"nativewind": "^4.2.1",
 				"react": "19.1.0",
@@ -10179,6 +10180,20 @@
 			"resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
 			"integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/iconsax-react-native": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/iconsax-react-native/-/iconsax-react-native-0.0.8.tgz",
+			"integrity": "sha512-iEQku/mu5Tuq5hBdEtQ3nhQJ0iPSmJj1lUu8PibSD9kPgIesA/gPCqU0U29l78l+LOUMgus8eTJZ0+1LJxUo3Q==",
+			"license": "MIT",
+			"dependencies": {
+				"prop-types": "^15.7.2"
+			},
+			"peerDependencies": {
+				"react": "*",
+				"react-native": ">=0.46",
+				"react-native-svg": ">=5.3"
+			}
 		},
 		"node_modules/iconv-lite": {
 			"version": "0.6.3",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 		"expo-symbols": "~1.0.7",
 		"expo-system-ui": "~6.0.8",
 		"expo-web-browser": "~15.0.8",
+		"iconsax-react-native": "^0.0.8",
 		"lucide-react-native": "^0.544.0",
 		"nativewind": "^4.2.1",
 		"react": "19.1.0",

--- a/schemas/auth.ts
+++ b/schemas/auth.ts
@@ -1,12 +1,10 @@
 import { LoginRequest } from '@vitalfit/sdk';
 import { z } from 'zod';
 
-// Definimos el esquema de validación para el login
 export const LoginSchema: z.ZodType<LoginRequest> = z.object({
 	email: z.string().email({ message: 'Por favor, introduce un correo válido.' }),
 	password: z.string().min(6, { message: 'La contraseña debe tener al menos 6 caracteres.' }),
 	context: z.string().optional(), // El SDK tiene un campo 'context' opcional
 });
 
-// También puedes inferir el tipo de TypeScript directamente del esquema
 export type LoginData = z.infer<typeof LoginSchema>;

--- a/schemas/register.ts
+++ b/schemas/register.ts
@@ -1,14 +1,11 @@
-// schemas/register.ts
 import { z } from 'zod';
 
-// Esquema para el Paso 1: Género
 export const Step1Schema = z.object({
 	gender: z.enum(['female', 'male', 'prefer-not-to-say'], {
 		errorMap: () => ({ message: 'Por favor, selecciona un género.' }),
 	}),
 });
 
-// Esquema para el Paso 2: Credenciales
 export const Step2Schema = z
 	.object({
 		email: z.string().email('El correo no es válido.'),
@@ -26,7 +23,6 @@ export const Step2Schema = z
 		path: ['confirmPassword'],
 	});
 
-// Esquema completo para el registro
 export const RegisterSchema = z
 	.object({
 		gender: z.enum(['female', 'male', 'prefer-not-to-say'], {

--- a/services/api.ts
+++ b/services/api.ts
@@ -1,21 +1,19 @@
-// src/services/api.ts
 import Constants from 'expo-constants';
 import { Alert } from 'react-native';
 
-let API_URL: string | undefined =
+const API_URL: string | undefined =
 	Constants.expoConfig?.extra?.EXPO_PUBLIC_API_URL ||
 	Constants.manifest?.extra?.EXPO_PUBLIC_API_URL ||
 	process.env.EXPO_PUBLIC_API_URL;
 
-// 🔍 Diagnóstico directo en el APK
 if (!API_URL) {
-	console.warn('⚠️ EXPO_PUBLIC_API_URL no encontrada en runtime');
+	console.warn('EXPO_PUBLIC_API_URL no encontrada en runtime');
 	Alert.alert(
 		'Error de configuración',
 		'La variable EXPO_PUBLIC_API_URL no está configurada en el APK.\n\nRevisa el archivo app.config.js o EAS Secrets.',
 	);
-	// Valor de fallback opcional (no crash)
-	API_URL = 'https://api-rm8x.onrender.com/v1';
+
+	//	API_URL = 'https://api-rm8x.onrender.com/v1';
 } else {
-	console.log('✅ API_URL detectada:', API_URL);
+	console.log('API_URL detectada:', API_URL);
 }

--- a/services/vitalfitSdk.ts
+++ b/services/vitalfitSdk.ts
@@ -1,7 +1,6 @@
 import { VitalFit } from '@vitalfit/sdk';
 import Constants from 'expo-constants';
 
-// Determinar si estamos en modo de desarrollo
 const isDevMode =
 	Constants.expoConfig?.extra?.EXPO_PUBLIC_API_URL === 'http://localhost:3000/v1' ||
 	Constants.manifest?.extra?.EXPO_PUBLIC_API_URL === 'http://localhost:3000/v1' ||


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Replaced the hardcoded user role logic in `DashboardScreen` with a dynamic role detection from the `vitalFitApi.user.WhoAmI(token)` response.  
The screen now renders the appropriate dashboard component (`DashboardInstructor`, `DashboardRecepcionist`, or default client dashboard) based on the authenticated user's role.  
Includes fallback handling for unknown or missing roles and maintains consistent loading and error handling.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change removes temporary testing code and ensures that user dashboards are rendered dynamically and securely according to their assigned role in the system.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- Verified dashboard rendering with real `WhoAmI` responses for each role type.
- Tested fallback behavior when the user role is missing or invalid.
- Confirmed backward compatibility with instructor and recepcionist dashboards.
- Validated that loading and API error states still behave as expected.

## Screenshots (if appropriate):
N/A
