### PR TITLE
fix(auth): corregir activación de cuenta de cliente en flujo de confirmación de correo

### DIFF
--- a/app/(auth)/confirm-email.tsx
+++ b/app/(auth)/confirm-email.tsx
@@ -37,7 +37,28 @@ export default function ConfirmEmailScreen() {
 		setIsLoading(true);
 
 		try {
-			await vitalFitApi.auth.verifyEmail(code.trim());
+			const storedPassword = await AsyncStorage.getItem('temp_password');
+
+			if (!storedPassword) {
+				showToast(
+					'error',
+					'Error',
+					'No se encontró la contraseña temporal. Intenta iniciar sesión manualmente.',
+				);
+				setTimeout(() => router.replace('/(auth)/login'), 2000);
+				return;
+			}
+
+			// 👇 PUT /auth/activate/{code} con password requerido
+			await vitalFitApi.client.put({
+				url: `/auth/activate/${code.trim()}`,
+				data: {
+					password: storedPassword,
+					confirm_password: storedPassword, // 👈 usa snake_case
+				},
+			});
+
+			showToast('success', '¡Éxito!', '¡Te has registrado exitosamente!');
 
 			showToast('success', '¡Éxito!', '¡Te has registrado exitosamente!');
 
@@ -88,6 +109,10 @@ export default function ConfirmEmailScreen() {
 		} catch (error: unknown) {
 			let errorMessage =
 				'Ocurrió un error inesperado al confirmar el correo. Inténtalo de nuevo.';
+			console.error(
+				'❌ Error al confirmar o iniciar sesión (detalle completo):',
+				JSON.stringify(error, null, 2),
+			);
 			if (isAPIError(error)) {
 				errorMessage = error.messages.join(', ');
 			} else if (error instanceof Error) {

--- a/app/(auth)/register.tsx
+++ b/app/(auth)/register.tsx
@@ -70,6 +70,7 @@ export default function RegisterScreen() {
 				birth_date: new Date(cleanedData.birthDate).toISOString().split('T')[0], // Convertir a Date y luego formatear
 				phone: cleanedData.phone,
 				profile_picture_url: '', // El SDK espera esto, aunque esté vacío
+				role_name: 'client',
 			};
 
 			// 🔹 Registro del usuario

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@react-navigation/bottom-tabs": "^7.4.0",
 				"@react-navigation/elements": "^2.6.3",
 				"@react-navigation/native": "^7.1.8",
-				"@vitalfit/sdk": "^0.0.30",
+				"@vitalfit/sdk": "^0.0.43",
 				"axios": "^1.12.2",
 				"clsx": "^2.1.1",
 				"date-fns": "^4.1.0",
@@ -5022,9 +5022,9 @@
 			}
 		},
 		"node_modules/@vitalfit/sdk": {
-			"version": "0.0.30",
-			"resolved": "https://registry.npmjs.org/@vitalfit/sdk/-/sdk-0.0.30.tgz",
-			"integrity": "sha512-ltwAbqTB4BC281MxmlqAoHf2R6BaFH4hmAlCS8L5BBqZqausrERfVuG22QXOqZGVhIauWLu3GMnW0tDfBkDWBA==",
+			"version": "0.0.43",
+			"resolved": "https://registry.npmjs.org/@vitalfit/sdk/-/sdk-0.0.43.tgz",
+			"integrity": "sha512-RWWQrE737NZoATnbAzRgDZWKiU9uSu5fHrB/1cUsQEdrnZZDhRCuD3tEmPgrahhX8NgC/tMhffnrUYUpyYGydQ==",
 			"license": "MIT",
 			"dependencies": {
 				"axios": "^1.12.2"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"@react-navigation/bottom-tabs": "^7.4.0",
 		"@react-navigation/elements": "^2.6.3",
 		"@react-navigation/native": "^7.1.8",
-		"@vitalfit/sdk": "^0.0.30",
+		"@vitalfit/sdk": "^0.0.43",
 		"axios": "^1.12.2",
 		"clsx": "^2.1.1",
 		"date-fns": "^4.1.0",


### PR DESCRIPTION
## Description

Se corrigió el flujo de activación de cuenta en la pantalla **ConfirmEmailScreen**.  
El endpoint `PUT /auth/activate/{code}` requería los campos `password` y `confirm_password`,  
pero el cliente enviaba `confirmPassword` (camelCase), lo que generaba error `400` en el backend.  
Ahora el body se envía correctamente en `snake_case` y el usuario cliente puede activar su cuenta sin errores.  

También se ajustó la recuperación de la contraseña temporal (`storedPassword`) desde AsyncStorage  
para incluirla correctamente en la activación y posterior login automático.

## Related Issue

Fixes internal issue: **Error de activación de cuenta en flujo de confirmación de correo (400 ConfirmPassword required)**

## Motivation and Context

El flujo de registro de usuarios cliente fallaba en la fase de activación (`PUT /auth/activate/{code}`)  
por incompatibilidad de nombres de campos entre frontend y backend.  
Con esta corrección se asegura la compatibilidad con la estructura `UpdateStaffPasswordPayload`  
y se permite la activación y login automático sin intervención manual.

## How Has This Been Tested?

- Registro de usuario cliente nuevo.  
- Ingreso del código de confirmación recibido por correo.  
- Activación correcta mediante `PUT /auth/activate/{code}`.  
- Login automático posterior exitoso con token recibido.  
- Validación de manejo de errores y mensajes toast.

## Screenshots (if appropriate):
N/A