### PR TITLE
Refactor/membership visual: Se mejoro las pantallas de horario y Reserva, más la de compra 

### DIFF
--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -12,14 +12,14 @@ import { Link, useRouter } from 'expo-router';
 import { Eye, EyeOff, SlidersVertical } from 'lucide-react-native';
 import { useState } from 'react';
 import {
-	Keyboard,
-	KeyboardAvoidingView,
-	Platform,
-	Text,
-	TextInput,
-	TouchableOpacity,
-	TouchableWithoutFeedback,
-	View,
+    Keyboard,
+    KeyboardAvoidingView,
+    Platform,
+    Text,
+    TextInput,
+    TouchableOpacity,
+    TouchableWithoutFeedback,
+    View,
 } from 'react-native';
 export default function LoginScreen() {
 	const { toastState, showToast, hideToast } = useToast();
@@ -74,7 +74,8 @@ export default function LoginScreen() {
 			} else if (error instanceof Error) {
 				errorMessage = error.message;
 			}
-			console.error('Error en el login:', error);
+			console.error('Error en el login (detalle completo):', JSON.stringify(error, null, 2));
+			console.error('Error en el login (objeto bruto):', error);
 			showToast('error', 'Error al iniciar sesión', errorMessage);
 		} finally {
 			setIsLoading(false);

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -151,7 +151,7 @@ export default function DashboardScreen() {
 					hasMembership={hasMembership}
 					daysRemaining={15}
 					onQRPress={() => setQrModalVisible(true)}
-					onGetMembershipPress={() => router.push('/memberships')}
+					onGetMembershipPress={() => router.push('/membership-entry')}
 				/>
 
 				{hasMembership && <UpcomingClassesCarousel classes={mockClasses} />}
@@ -162,20 +162,20 @@ export default function DashboardScreen() {
 					onPrimaryActionPress={(id) =>
 						hasMembership
 							? router.push(`/routine/details?id=${id}`)
-							: router.push('/memberships')
+							: router.push('/membership-entry')
 					}
 				/>
 
 				{/* Banners adicionales */}
 				{hasMembership ? (
 					<View className='gap-3'>
-						<BirthdayOfferBanner onPress={() => router.push('/memberships')} />
+						<BirthdayOfferBanner onPress={() => router.push('/membership-entry')} />
 
 						<WeeklyChallengeBanner
 							onPress={() => console.log('Abrir challenge:', 'plank-challenge')}
 						/>
 
-						<BirthdayOfferBanner onPress={() => router.push('/memberships')} />
+						<BirthdayOfferBanner onPress={() => router.push('/membership-entry')} />
 
 						<CrossFitBanner
 							imageSource={require('@/assets/images/crossfit.png')}
@@ -186,7 +186,7 @@ export default function DashboardScreen() {
 				) : (
 					<>
 						{/* Servicios ya viene de UpcomingRoutinesSection en modo guest */}
-						<BirthdayOfferBanner onPress={() => router.push('/memberships')} />
+						<BirthdayOfferBanner onPress={() => router.push('/membership-entry')} />
 
 						<RNText style={{ color: '#111827', fontWeight: '700', fontSize: 18, marginTop: 16, marginBottom: 8 }}>
 							Paquetes
@@ -195,12 +195,12 @@ export default function DashboardScreen() {
 							<CrossFitBanner
 								imageSource={require('@/assets/images/rutina.png')}
 								title='CrossFit - 4 sesiones'
-								onPress={() => router.push('/memberships')}
+								onPress={() => router.push('/membership-entry')}
 							/>
 							<CrossFitBanner
 								imageSource={require('@/assets/images/rutin.png')}
 								title='CrossFit - 4 sesiones'
-								onPress={() => router.push('/memberships')}
+								onPress={() => router.push('/membership-entry')}
 							/>
 						</View>
 						<View className='gap-3'>

--- a/app/(tabs)/profile/cancel-membership.tsx
+++ b/app/(tabs)/profile/cancel-membership.tsx
@@ -23,7 +23,7 @@ export default function CancelMembershipScreen() {
 				<View className='w-full'>
 					<SecondaryButton
 						title='Mantener membresía'
-						onPress={() => router.push('/memberships')}
+						onPress={() => router.push('/membership-entry')}
 					/>
 					<View className='h-4' />
 					<PrimaryButton

--- a/app/(tabs)/profile/index.tsx
+++ b/app/(tabs)/profile/index.tsx
@@ -102,7 +102,7 @@ export default function ProfileScreen() {
 
 				<ProfileMenuItem
 					title="Membresía"
-					onPress={() => router.replace('/profile/cancel-membership')}
+					onPress={() => router.push('/membership-entry')}
 				/>
 
 				<ProfileMenuItem

--- a/app/(tabs)/schedule.tsx
+++ b/app/(tabs)/schedule.tsx
@@ -1,5 +1,6 @@
 import { MonthCalendar } from '@/components/auth/dashboard/monthcalendar';
 import { WeekCalendar } from '@/components/auth/dashboard/weekcalendar';
+import RoutinesCarousel, { RoutineChip } from '@/components/auth/training/RoutinesCarousel';
 import ClassCard from '@/components/ClassCard';
 import Dropdown from '@/components/Dropdown';
 import { ThemedText } from '@/components/themed-text';
@@ -8,14 +9,7 @@ import { useReservations } from '@/contexts/reservations';
 import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
 // Heroicons (optional alternative)
-import {
-	BoltIcon,
-	FireIcon as FireIconH,
-	HeartIcon as HeartIconH,
-	SparklesIcon as SparklesIconH,
-} from 'react-native-heroicons/solid';
 // Lucide icons (default)
-import { Activity, Flame, Flower2, Heart } from 'lucide-react-native';
 import React, { useState } from 'react';
 import { Pressable, ScrollView, View } from 'react-native';
 
@@ -45,7 +39,7 @@ const classes = [
 		branch: 'Sucursal Centro',
 		imageUrl: require('@/assets/images/yoga-w.jpg'),
 		capacity: 25,
-		occupied: 20,
+		occupied: 18,
 	},
 	// Full class example
 	{
@@ -55,271 +49,247 @@ const classes = [
 		branch: 'Sucursal Sur',
 		imageUrl: require('@/assets/images/crossfit-w.jpg'),
 		capacity: 25,
-		occupied: 25,
+		occupied: 24,
 	},
+];
+
+const exploreRoutineChips: RoutineChip[] = [
+    { id: 'yoga', label: 'Yoga', image: require('@/assets/images/yoga (2).png') },
+    { id: 'hiit', label: 'HIIT', image: require('@/assets/images/hiit.png') },
+    { id: 'kick', label: 'Kick\nBoxing', image: require('@/assets/images/kick boxing.png') },
+    { id: 'pilates', label: 'Pilates', image: require('@/assets/images/pilates.png') },
 ];
 
 type Reservation = {
-	time: string;
-	title: string;
-	instructor: string;
-	branch: string;
-	imageUrl: string | number;
-	status: 'assisted' | 'absent' | 'cancelled';
-	capacity: number;
-	occupied: number;
+    time: string;
+    title: string;
+    instructor: string;
+    branch: string;
+    imageUrl: string | number;
+    status: 'assisted' | 'absent' | 'cancelled';
+    capacity: number;
+    occupied: number;
 };
 
 const reservations: Reservation[] = [
-	{
-		time: '10:00 AM',
-		title: 'Yoga Flow',
-		instructor: 'Con Sofia Ramirez',
-		branch: 'Sucursal Centro',
-		imageUrl: require('@/assets/images/yoga-w.jpg'),
-		status: 'assisted',
-		capacity: 25,
-		occupied: 18,
-	},
-	{
-		time: '11:00 AM',
-		title: 'Spinning',
-		instructor: 'Con Carlos Mendoza',
-		branch: 'Sucursal Norte',
-		imageUrl: require('@/assets/images/spinning-w.jpg'),
-		status: 'cancelled',
-		capacity: 25,
-		occupied: 22,
-	},
-	{
-		time: '12:00 PM',
-		title: 'Zumba',
-		instructor: 'Con Laura Torres',
-		branch: 'Sucursal Sur',
-		imageUrl: require('@/assets/images/zumba-w.jpg'),
-		status: 'absent',
-		capacity: 25,
-		occupied: 25,
-	},
-	{
-		time: '07:00 AM',
-		title: 'Crossfit',
-		instructor: 'Con Laura Torres',
-		branch: 'Sucursal Sur',
-		imageUrl: require('@/assets/images/crossfit-w.jpg'),
-		status: 'assisted',
-		capacity: 25,
-		occupied: 25,
-	},
+    {
+        time: '10:00 AM',
+        title: 'Yoga Flow',
+        instructor: 'Con Sofia Ramirez',
+        branch: 'Sucursal Centro',
+        imageUrl: require('@/assets/images/yoga-w.jpg'),
+        status: 'assisted',
+        capacity: 25,
+        occupied: 18,
+    },
+    {
+        time: '11:00 AM',
+        title: 'Spinning',
+        instructor: 'Con Carlos Mendoza',
+        branch: 'Sucursal Norte',
+        imageUrl: require('@/assets/images/spinning-w.jpg'),
+        status: 'cancelled',
+        capacity: 25,
+        occupied: 22,
+    },
+    {
+        time: '07:00 AM',
+        title: 'Crossfit',
+        instructor: 'Con Laura Torres',
+        branch: 'Sucursal Sur',
+        imageUrl: require('@/assets/images/crossfit-w.jpg'),
+        status: 'assisted',
+        capacity: 25,
+        occupied: 23,
+    },
 ];
 
 export default function HorariosScreen() {
-	const router = useRouter();
-	const [activeTab, setActiveTab] = useState<'classes' | 'reservas' | 'explorar'>('classes'); // State to manage active tab
-	const { isReserved } = useReservations();
+    const router = useRouter();
+    const [activeTab, setActiveTab] = useState<'classes' | 'reservas' | 'explorar'>('classes');
+    const { isReserved } = useReservations();
 
-	return (
-		<ThemedView className='flex-1 bg-white dark:bg-neutral-950 p-4 pt-12'>
-			<ScrollView showsVerticalScrollIndicator={false}>
-				<View className='mb-4'>
-					<Image
-						source={require('@/assets/images/vitalfit-whatsapp.jpeg')}
-						style={{ width: 120, height: 50, borderRadius: 6 }}
-						contentFit='cover'
-					/>
-					<ThemedText className='mt-3 text-xs tracking-widest text-white/80'>
-						CALENDARIO
-					</ThemedText>
-				</View>
+    return (
+        <ThemedView
+            lightColor='#050816'
+            darkColor='#050816'
+            className='flex-1 p-4 pt-12'>
+            <ScrollView
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={{ paddingBottom: 64 }}>
+                <View className='mb-4'>
+                    <Image
+                        source={require('@/assets/images/vitalfit-whatsapp.jpeg')}
+                        style={{ width: 120, height: 50, borderRadius: 6 }}
+                        contentFit='cover'
+                    />
+                    <ThemedText
+                        lightColor='#ffffff'
+                        darkColor='#ffffff'
+                        className='mt-3 text-xs tracking-widest'>
+                        CALENDARIO
+                    </ThemedText>
+                </View>
 
-				<View className='mb-6'>
-					{activeTab === 'reservas' ? <MonthCalendar /> : <WeekCalendar />}
-				</View>
+                <View className='mb-6'>
+                    {activeTab === 'reservas' ? <MonthCalendar /> : <WeekCalendar />}
+                </View>
 
-				<View className='flex-row mb-6 border rounded-xl border-neutral-200 dark:border-neutral-700 p-1'>
-					<Pressable
-						onPress={() => setActiveTab('classes')}
-						style={({ pressed }) => [{ transform: [{ scale: pressed ? 1.05 : 1 }] }]}
-						className={`flex-1 items-center py-3 rounded-lg ${
-							activeTab === 'classes' ? 'bg-neutral-100 dark:bg-neutral-800' : ''
-						}`}>
-						<ThemedText
-							className={`text-lg font-semibold ${
-								activeTab === 'classes'
-									? 'text-orange-500'
-									: 'text-neutral-500 dark:text-neutral-400'
-							}`}>
-							Clases
-						</ThemedText>
-					</Pressable>
-					<Pressable
-						onPress={() => setActiveTab('reservas')}
-						style={({ pressed }) => [{ transform: [{ scale: pressed ? 1.05 : 1 }] }]}
-						className={`flex-1 items-center py-3 rounded-lg ${
-							activeTab === 'reservas' ? 'bg-neutral-100 dark:bg-neutral-800' : ''
-						}`}>
-						<ThemedText
-							className={`text-lg font-semibold text-center ${
-								activeTab === 'reservas'
-									? 'text-orange-500'
-									: 'text-neutral-500 dark:text-neutral-400'
-							}`}>
-							Reservas
-						</ThemedText>
-					</Pressable>
-					<Pressable
-						onPress={() => setActiveTab('explorar')}
-						style={({ pressed }) => [{ transform: [{ scale: pressed ? 1.05 : 1 }] }]}
-						className={`flex-1 items-center py-3 rounded-lg ${
-							activeTab === 'explorar' ? 'bg-neutral-100 dark:bg-neutral-800' : ''
-						}`}>
-						<ThemedText
-							className={`text-lg font-semibold ${
-								activeTab === 'explorar'
-									? 'text-orange-500'
-									: 'text-neutral-500 dark:text-neutral-400'
-							}`}>
-							Explorar
-						</ThemedText>
-					</Pressable>
-				</View>
+                <View className='flex-row mb-6 border rounded-xl border-neutral-800 bg-neutral-900 p-1'>
+                    <Pressable
+                        onPress={() => setActiveTab('classes')}
+                        style={({ pressed }) => [{ transform: [{ scale: pressed ? 1.05 : 1 }] }]}
+                        className={`flex-1 items-center py-3 rounded-lg ${
+                            activeTab === 'classes' ? 'bg-neutral-800' : 'bg-transparent'
+                        }`}
+                    >
+                        <ThemedText
+                            lightColor='#ffffff'
+                            darkColor='#ffffff'
+                            className='text-lg font-semibold'>
+                            Clases
+                        </ThemedText>
+                    </Pressable>
+                    <Pressable
+                        onPress={() => setActiveTab('reservas')}
+                        style={({ pressed }) => [{ transform: [{ scale: pressed ? 1.05 : 1 }] }]}
+                        className={`flex-1 items-center py-3 rounded-lg ${
+                            activeTab === 'reservas' ? 'bg-neutral-800' : 'bg-transparent'
+                        }`}
+                    >
+                        <ThemedText
+                            lightColor='#ffffff'
+                            darkColor='#ffffff'
+                            className='text-lg font-semibold text-center'>
+                            Reservas
+                        </ThemedText>
+                    </Pressable>
+                    <Pressable
+                        onPress={() => setActiveTab('explorar')}
+                        style={({ pressed }) => [{ transform: [{ scale: pressed ? 1.05 : 1 }] }]}
+                        className={`flex-1 items-center py-3 rounded-lg ${
+                            activeTab === 'explorar' ? 'bg-neutral-800' : 'bg-transparent'
+                        }`}
+                    >
+                        <ThemedText
+                            lightColor='#ffffff'
+                            darkColor='#ffffff'
+                            className='text-lg font-semibold'>
+                            Explorar
+                        </ThemedText>
+                    </Pressable>
+                </View>
 
-				<View className='mb-6'>
-					<View className='flex-row items-center justify-between mt-2'>
-						<ThemedText className='text-2xl font-extrabold'>Proximas clases</ThemedText>
-						<View style={{ width: 120 }}>
-							<Dropdown label='Filter' onPress={() => {}} />
-						</View>
-					</View>
-				</View>
+                <View className='mb-6'>
+                    <View className='flex-row items-center justify-between mt-2'>
+                        <ThemedText
+                            lightColor='#ffffff'
+                            darkColor='#ffffff'
+                            className='text-2xl font-extrabold'>
+                            Proximas clases
+                        </ThemedText>
+                        <View style={{ width: 120 }}>
+                            <Dropdown label='Filter' onPress={() => {}} />
+                        </View>
+                    </View>
+                </View>
 
-				{/* Categorías */}
-				{(activeTab === 'classes' || activeTab === 'explorar') && (
-					<View className='mb-5'>
-						<ScrollView horizontal showsHorizontalScrollIndicator={false}>
-							{(() => {
-								const ICON_SET: 'lucide' | 'heroicons' = 'lucide'; // cambia a 'heroicons' si prefieres ese set
-								const items =
-									ICON_SET === 'lucide'
-										? [
-												{ label: 'Yoga', Icon: Flower2 },
-												{ label: 'HIIT', Icon: Activity },
-												{ label: 'Kick Boxing', Icon: Flame },
-												{ label: 'Pilates', Icon: Heart },
-											]
-										: [
-												{ label: 'Yoga', Icon: SparklesIconH },
-												{ label: 'HIIT', Icon: BoltIcon },
-												{ label: 'Kick Boxing', Icon: FireIconH },
-												{ label: 'Pilates', Icon: HeartIconH },
-											];
-								return items.map(({ label, Icon }) => (
-									<Pressable key={label} className='mr-4'>
-										<View className='items-center'>
-											<View className='w-16 h-16 rounded-xl bg-neutral-900 border border-neutral-700 items-center justify-center mb-2'>
-												<Icon color={'#f97316'} size={24} strokeWidth={2} />
-											</View>
-											<ThemedText className='text-[11px] text-neutral-300'>
-												{label}
-											</ThemedText>
-										</View>
-									</Pressable>
-								));
-							})()}
-						</ScrollView>
-					</View>
-				)}
+                {activeTab === 'explorar' && (
+                    <View className='mb-5'>
+                        <RoutinesCarousel items={exploreRoutineChips} showTitle={false} />
+                    </View>
+                )}
 
-				{activeTab === 'classes' && (
-					<View>
-						{classes.map((classItem, index) => (
-							<ClassCard
-								key={index}
-								time={classItem.time}
-								title={classItem.title}
-								instructor={classItem.instructor}
-								branch={classItem.branch}
-								imageUrl={classItem.imageUrl}
-								variant='overlay'
-								category={'categoría'}
-								reserved={isReserved(`${classItem.title}|${classItem.time}`)}
-								onPress={(classData) => {
-									router.push({
-										pathname: '/class-details',
-										params: {
-											...classData,
-											capacity: String(classItem.capacity),
-											occupied: String(classItem.occupied),
-										},
-									});
-								}}
-							/>
-						))}
-					</View>
-				)}
+                {activeTab === 'classes' && (
+                    <View>
+                        {classes.map((classItem, index) => (
+                            <ClassCard
+                                key={index}
+                                time={classItem.time}
+                                title={classItem.title}
+                                instructor={classItem.instructor}
+                                branch={classItem.branch}
+                                imageUrl={classItem.imageUrl}
+                                variant='overlay'
+                                category={'categoría'}
+                                reserved={isReserved(`${classItem.title}|${classItem.time}`)}
+                                onPress={(classData) => {
+                                    router.push({
+                                        pathname: '/class-details',
+                                        params: {
+                                            ...classData,
+                                            capacity: String(classItem.capacity),
+                                            occupied: String(classItem.occupied),
+                                        },
+                                    });
+                                }}
+                            />
+                        ))}
+                    </View>
+                )}
 
-				{activeTab === 'reservas' && (
-					<View>
-						<ThemedText className='text-xl font-bold mb-4'>Mis reservas</ThemedText>
-						{reservations.map((reservation, index) => (
-							<ClassCard
-								key={index}
-								time={reservation.time}
-								title={reservation.title}
-								instructor={reservation.instructor}
-								branch={reservation.branch}
-								imageUrl={reservation.imageUrl}
-								variant='overlay'
-								category={'categoría'}
-								reserved={isReserved(`${reservation.title}|${reservation.time}`)}
-								onPress={(classData) => {
-									router.push({
-										pathname: '/class-details',
-										params: {
-											...classData,
-											capacity: String(reservation.capacity),
-											occupied: String(reservation.occupied),
-										},
-									});
-								}}
-							/>
-						))}
-						{reservations.length === 0 && (
-							<ThemedText className='text-neutral-500'>
-								Aún no tienes reservas.
-							</ThemedText>
-						)}
-					</View>
-				)}
+                {activeTab === 'reservas' && (
+                    <View>
+                        <ThemedText className='text-xl font-bold mb-4'>Mis reservas</ThemedText>
+                        {reservations.map((reservation, index) => (
+                            <ClassCard
+                                key={index}
+                                time={reservation.time}
+                                title={reservation.title}
+                                instructor={reservation.instructor}
+                                branch={reservation.branch}
+                                imageUrl={reservation.imageUrl}
+                                variant='overlay'
+                                category={'categoría'}
+                                reserved={isReserved(`${reservation.title}|${reservation.time}`)}
+                                onPress={(classData) => {
+                                    router.push({
+                                        pathname: '/class-details',
+                                        params: {
+                                            ...classData,
+                                            capacity: String(reservation.capacity),
+                                            occupied: String(reservation.occupied),
+                                        },
+                                    });
+                                }}
+                            />
+                        ))}
+                        {reservations.length === 0 && (
+                            <ThemedText className='text-neutral-500'>
+                                Aún no tienes reservas.
+                            </ThemedText>
+                        )}
+                    </View>
+                )}
 
-				{activeTab === 'explorar' && (
-					<View>
-						{classes.map((classItem, index) => (
-							<ClassCard
-								key={index}
-								time={classItem.time}
-								title={classItem.title}
-								instructor={classItem.instructor}
-								branch={classItem.branch}
-								imageUrl={classItem.imageUrl}
-								variant='overlay'
-								category={'categoría'}
-								reserved={isReserved(`${classItem.title}|${classItem.time}`)}
-								onPress={(classData) => {
-									router.push({
-										pathname: '/class-details',
-										params: {
-											...classData,
-											capacity: String(classItem.capacity),
-											occupied: String(classItem.occupied),
-										},
-									});
-								}}
-							/>
-						))}
-					</View>
-				)}
-			</ScrollView>
-		</ThemedView>
-	);
+                {activeTab === 'explorar' && (
+                    <View>
+                        {classes.map((classItem, index) => (
+                            <ClassCard
+                                key={index}
+                                time={classItem.time}
+                                title={classItem.title}
+                                instructor={classItem.instructor}
+                                branch={classItem.branch}
+                                imageUrl={classItem.imageUrl}
+                                variant='overlay'
+                                category={'categoría'}
+                                reserved={isReserved(`${classItem.title}|${classItem.time}`)}
+                                onPress={(classData) => {
+                                    router.push({
+                                        pathname: '/class-details',
+                                        params: {
+                                            ...classData,
+                                            capacity: String(classItem.capacity),
+                                            occupied: String(classItem.occupied),
+                                        },
+                                    });
+                                }}
+                            />
+                        ))}
+                    </View>
+                )}
+            </ScrollView>
+        </ThemedView>
+    );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -103,7 +103,7 @@ export default function RootLayout() {
 						name='class-details'
 						options={{
 							title: 'Detalles de la Clase',
-							headerShown: true,
+							headerShown: false,
 							headerBackTitle: 'Volver',
 						}}
 					/>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -79,6 +79,13 @@ export default function RootLayout() {
 						}}
 					/>
 					<Stack.Screen
+						name='membership-entry'
+						options={{
+							title: '',
+							headerShown: false,
+						}}
+					/>
+					<Stack.Screen
 						name='memberships'
 						options={{
 							title: '',

--- a/app/class-details.tsx
+++ b/app/class-details.tsx
@@ -1,177 +1,328 @@
 import { PrimaryButton } from '@/components/PrimaryButton';
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
+import { ToastNotification } from '@/components/ToastNotification';
 import { useReservations } from '@/contexts/reservations';
+import { useToast } from '@/hooks/useToast';
 import { Image } from 'expo-image';
 import { useLocalSearchParams } from 'expo-router';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
-import { StarIcon } from 'react-native-heroicons/solid';
-
-export default function ClassDetailsScreen() {
-	const { time, title, instructor, imageUrl, capacity, occupied } = useLocalSearchParams();
-	const { isReserved, reserve } = useReservations();
-
-	const todayFormatted = useMemo(() => {
-		try {
-			return new Date().toLocaleDateString('es-ES', {
-				day: '2-digit',
-				month: 'long',
-				year: 'numeric',
-			});
-		} catch {
-			return '';
-		}
-	}, []);
-
-	const heroSource = useMemo(() => {
-		const t = String(title || '').toLowerCase();
-		const localByTitle: Record<string, number> = {
-			zumba: require('@/assets/images/zumba-w.jpg'),
-			spinning: require('@/assets/images/spinning-w.jpg'),
-			'yoga flow': require('@/assets/images/yoga-w.jpg'),
-			crossfit: require('@/assets/images/crossfit-w.jpg'),
-		};
-		const fromTitle = localByTitle[t];
-		const url = imageUrl as string | undefined;
-		if (url && /^https?:\/\//i.test(url)) return { uri: url };
-		if (fromTitle) return fromTitle;
-		return require('@/assets/images/yoga-w.jpg');
-	}, [imageUrl, title]);
-
-	const description = useMemo(() => {
-		const t = String(title || '').toLowerCase();
-		const map: Record<string, string> = {
-			zumba: 'Clase de baile fitness con ritmos latinos para mejorar resistencia y coordinación. Ideal para todos los niveles y enfocada en divertirse mientras quemas calorías.',
-			spinning:
-				'Entrenamiento en bicicleta estacionaria de alta intensidad que mejora la capacidad cardiovascular y fortalece piernas y glúteos con intervalos y cambios de ritmo.',
-			'yoga flow':
-				'Secuencia fluida de posturas que trabaja fuerza, flexibilidad y respiración consciente. Perfecta para reducir el estrés y mejorar la movilidad general.',
-			crossfit:
-				'Entrenamiento funcional de alta intensidad que combina levantamiento olímpico, gimnasia y trabajo metabólico. Mejora fuerza, potencia y resistencia con WODs variados.',
-		};
-		return (
-			map[t] ||
-			'Entrenamiento diseñado para mejorar tu condición física con foco en técnica y progreso seguro. Incluye trabajo de fuerza, movilidad y resistencia.'
-		);
-	}, [title]);
-
-	const capNum = Number(capacity ?? 25);
-	const occNum = Number(occupied ?? 18);
-	const isFull = occNum >= capNum;
-
-	const id = useMemo(() => `${String(title || '')}|${String(time || '')}`, [title, time]);
-	const reserved = isReserved(id);
-
-	const timeRange = useMemo(() => {
-		const raw = String(time || '').trim();
-		if (!raw) return '07:00 - 08:00 AM';
-		if (raw.includes('-')) return raw; // already a range
-		// parse 12h like '07:00 AM'
-		const m = raw.match(/^(\d{1,2}):(\d{2})\s*([AP]M)$/i);
-		if (!m) return raw; // unknown format, show raw
-		const [, hh, mm, ap] = m;
-		let hour = parseInt(hh, 10) % 12;
-		if (ap.toUpperCase() === 'PM') hour += 12;
-		const start = new Date(2000, 0, 1, hour, parseInt(mm, 10));
-		const end = new Date(start.getTime() + 60 * 60 * 1000);
-		const fmt = (d: Date) => {
-			let h = d.getHours();
-			const minutes = d.getMinutes().toString().padStart(2, '0');
-			const suffix = h >= 12 ? 'PM' : 'AM';
-			h = h % 12;
-			if (h === 0) h = 12;
-			return `${h.toString().padStart(2, '0')}:${minutes} ${suffix}`;
-		};
-		return `${fmt(start)} - ${fmt(end)}`;
-	}, [time]);
-
-	return (
-		<ThemedView className='flex-1 bg-white dark:bg-neutral-950 p-4'>
-			<ScrollView showsVerticalScrollIndicator={false}>
-				<Image source={heroSource} style={styles.heroImage} contentFit='cover' />
-
-				<ThemedText className='text-3xl font-extrabold mt-6 mb-2'>
-					{String(title || 'Nombre de la clase').toUpperCase()}
-				</ThemedText>
-
-				<View className='mb-1'>
-					<ThemedText className='text-neutral-400'>{todayFormatted}</ThemedText>
-				</View>
-
-				<View className='mb-1'>
-					<ThemedText className={`${isFull ? 'text-red-400' : 'text-neutral-300'}`}>
-						{occNum} / {capNum} cupos ocupados
-					</ThemedText>
-				</View>
-
-				<View className='mb-4'>
-					<ThemedText className='text-orange-500 font-bold'>{timeRange}</ThemedText>
-				</View>
-
-				<View className='flex-row items-center mb-4'>
-					<StarIcon size={16} color='#F59E0B' />
-					<ThemedText className='ml-2 text-neutral-300'>4.9 (231 reviews)</ThemedText>
-				</View>
-
-				<View className='flex-row items-center mb-6'>
-					<Image
-						source={{ uri: 'https://randomuser.me/api/portraits/men/32.jpg' }}
-						style={{ width: 28, height: 28, borderRadius: 9999 }}
-						contentFit='cover'
-					/>
-					<ThemedText className='ml-2 text-neutral-200'>
-						{String(instructor || 'Nombre del Instructor')}
-					</ThemedText>
-				</View>
-
-				<View className='mb-6'>
-					<ThemedText className='font-bold mb-1'>Descripción de la clase:</ThemedText>
-					<ThemedText className='text-neutral-300'>{description}</ThemedText>
-				</View>
-
-				<View className='mb-8'>
-					<ThemedText className='text-orange-500 font-semibold'>
-						Nivel: intermedio
-					</ThemedText>
-				</View>
-
-				<View className='mb-6'>
-					<PrimaryButton
-						title={isFull ? 'Clase llena' : reserved ? 'Reservado' : 'Reservar'}
-						disabled={isFull || reserved}
-						style={{ backgroundColor: isFull || reserved ? '#6b7280' : undefined }}
-						onPress={async () => {
-							if (isFull || reserved) return;
-							const img =
-								typeof heroSource === 'number'
-									? heroSource
-									: (imageUrl as string | number | undefined);
-							await reserve({
-								id,
-								title: String(title || ''),
-								time: String(time || ''),
-								instructor: String(instructor || ''),
-								imageUrl: img,
-							});
-						}}
-					/>
-				</View>
-
-				<View className='items-center justify-center mb-2'>
-					<ThemedText className='text-neutral-400 italic text-center'>
-						“Podrás cancelar hasta 2h antes del inicio”
-					</ThemedText>
-				</View>
-			</ScrollView>
-		</ThemedView>
-	);
-}
+import { CheckCircleIcon, ExclamationCircleIcon, StarIcon } from 'react-native-heroicons/solid';
 
 const styles = StyleSheet.create({
-	heroImage: {
-		width: '100%',
-		height: 200,
-		borderRadius: 16,
-	},
+  heroImage: {
+    width: '100%',
+    height: 180,
+    borderRadius: 16,
+  },
 });
+
+export default function ClassDetailsScreen() {
+  const { time, title, instructor, imageUrl, capacity, occupied } = useLocalSearchParams();
+  const { isReserved, reserve, cancel } = useReservations();
+
+  const todayFormatted = useMemo(() => {
+    try {
+      return new Date().toLocaleDateString('es-ES', {
+        day: '2-digit',
+        month: 'long',
+        year: 'numeric',
+      });
+    } catch {
+      return '';
+    }
+  }, []);
+
+  const heroSource = useMemo(() => {
+    const t = String(title || '').toLowerCase();
+    const localByTitle: Record<string, number> = {
+      zumba: require('@/assets/images/zumba-w.jpg'),
+      spinning: require('@/assets/images/spinning-w.jpg'),
+      'yoga flow': require('@/assets/images/yoga-w.jpg'),
+      crossfit: require('@/assets/images/crossfit-w.jpg'),
+    };
+    const fromTitle = localByTitle[t];
+    const url = imageUrl as string | undefined;
+    if (url && /^https?:\/\//i.test(url)) return { uri: url };
+    if (fromTitle) return fromTitle;
+    return require('@/assets/images/yoga-w.jpg');
+  }, [imageUrl, title]);
+
+  const description = useMemo(() => {
+    const t = String(title || '').toLowerCase();
+    const map: Record<string, string> = {
+      zumba: 'Clase de baile fitness con ritmos latinos para mejorar resistencia y coordinación. Ideal para todos los niveles y enfocada en divertirse mientras quemas calorías.',
+      spinning:
+        'Entrenamiento en bicicleta estacionaria de alta intensidad que mejora la capacidad cardiovascular y fortalece piernas y glúteos con intervalos y cambios de ritmo.',
+      'yoga flow':
+        'Secuencia fluida de posturas que trabaja fuerza, flexibilidad y respiración consciente. Perfecta para reducir el estrés y mejorar la movilidad general.',
+      crossfit:
+        'Entrenamiento funcional de alta intensidad que combina levantamiento olímpico, gimnasia y trabajo metabólico. Mejora fuerza, potencia y resistencia con WODs variados.',
+    };
+    return (
+      map[t] ||
+      'Entrenamiento diseñado para mejorar tu condición física con foco en técnica y progreso seguro. Incluye trabajo de fuerza, movilidad y resistencia.'
+    );
+  }, [title]);
+
+  const capNum = Number(capacity ?? 25);
+  const occNumInitial = Number(occupied ?? 18);
+  const [forceFull, setForceFull] = useState(false);
+  const isFullInitial = occNumInitial >= capNum;
+  const effectiveFull = isFullInitial || forceFull;
+  const occNum = effectiveFull ? capNum : occNumInitial;
+
+  const id = useMemo(() => `${String(title || '')}|${String(time || '')}`, [title, time]);
+  const reserved = isReserved(id);
+  const { toastState, showToast, hideToast } = useToast();
+  const isCrossfitCompleted =
+    String(title || '').toLowerCase() === 'crossfit' && effectiveFull;
+
+  const timeRange = useMemo(() => {
+    const raw = String(time || '').trim();
+    if (!raw) return '07:00 - 08:00 AM';
+    if (raw.includes('-')) return raw; // already a range
+    // parse 12h like '07:00 AM'
+    const m = raw.match(/^(\d{1,2}):(\d{2})\s*([AP]M)$/i);
+    if (!m) return raw; // unknown format, show raw
+    const [, hh, mm, ap] = m;
+    let hour = parseInt(hh, 10) % 12;
+    if (ap.toUpperCase() === 'PM') hour += 12;
+    const start = new Date(2000, 0, 1, hour, parseInt(mm, 10));
+    const end = new Date(start.getTime() + 60 * 60 * 1000);
+    const fmt = (d: Date) => {
+      let h = d.getHours();
+      const minutes = d.getMinutes().toString().padStart(2, '0');
+      const suffix = h >= 12 ? 'PM' : 'AM';
+      h = h % 12;
+      if (h === 0) h = 12;
+      return `${h.toString().padStart(2, '0')}:${minutes} ${suffix}`;
+    };
+    return `${fmt(start)} - ${fmt(end)}`;
+  }, [time]);
+
+  return (
+    <ThemedView
+      lightColor='#050816'
+      darkColor='#050816'
+      className='flex-1 p-4 pt-12'>
+      <ToastNotification
+        type={toastState.type}
+        title={toastState.title}
+        message={toastState.message}
+        visible={toastState.visible}
+        onClose={hideToast}
+      />
+      <ScrollView showsVerticalScrollIndicator={false}>
+        <Image source={heroSource} style={styles.heroImage} contentFit='cover' />
+
+        <ThemedText
+          lightColor='#ffffff'
+          darkColor='#ffffff'
+          className='text-3xl font-extrabold mt-4 mb-1'>
+          {String(title || 'Nombre de la clase').toUpperCase()}
+        </ThemedText>
+
+        <View className='mb-1'>
+          <ThemedText
+            lightColor='#d4d4d4'
+            darkColor='#d4d4d4'
+            className='text-sm'>
+            {todayFormatted}
+          </ThemedText>
+        </View>
+
+        {effectiveFull && !isCrossfitCompleted && (
+          <View
+            className='mb-2 flex-row items-center rounded-2xl px-4 py-2'
+            style={{ backgroundColor: '#fecaca' }}>
+            <View
+              className='items-center justify-center mr-3 rounded-full'
+              style={{ width: 26, height: 26, backgroundColor: '#f97373' }}>
+              <ExclamationCircleIcon size={15} color='#ffffff' />
+            </View>
+            <ThemedText
+              lightColor='#b91c1c'
+              darkColor='#b91c1c'
+              className='text-xs font-medium'>
+              La clase se llenó mientras la reservabas.
+            </ThemedText>
+          </View>
+        )}
+
+        <View className='mb-1'>
+          <ThemedText
+            lightColor={effectiveFull ? '#fca5a5' : '#e5e5e5'}
+            darkColor={effectiveFull ? '#fca5a5' : '#e5e5e5'}
+            className='text-sm'>
+            {occNum} / {capNum} cupos ocupados
+          </ThemedText>
+        </View>
+
+        {reserved && (
+          <View className='mb-3'>
+            <View className='self-start bg-emerald-500 px-3 py-1 rounded-full'>
+              <ThemedText
+                lightColor='#ffffff'
+                darkColor='#ffffff'
+                className='text-xs font-semibold'>
+                Reservada
+              </ThemedText>
+            </View>
+          </View>
+        )}
+
+        <View className='mb-3'>
+          <ThemedText
+            lightColor='#f97316'
+            darkColor='#f97316'
+            className='font-bold'>
+            {timeRange}
+          </ThemedText>
+        </View>
+
+        <View className='flex-row items-center mb-3'>
+          <StarIcon size={16} color='#F59E0B' />
+          <ThemedText
+            lightColor='#e5e5e5'
+            darkColor='#e5e5e5'
+            className='ml-2 text-sm'>
+            4.9 (231 reviews)
+          </ThemedText>
+        </View>
+
+        <View className='flex-row items-center mb-4'>
+          <Image
+            source={{ uri: 'https://randomuser.me/api/portraits/men/32.jpg' }}
+            style={{ width: 28, height: 28, borderRadius: 9999 }}
+            contentFit='cover'
+          />
+          <ThemedText
+            lightColor='#e5e5e5'
+            darkColor='#e5e5e5'
+            className='ml-2'>
+            {String(instructor || 'Nombre del Instructor')}
+          </ThemedText>
+        </View>
+
+        <View className='mb-4'>
+          <ThemedText
+            lightColor='#ffffff'
+            darkColor='#ffffff'
+            className='mb-1'>
+            Descripción de la clase:
+          </ThemedText>
+          <ThemedText
+            lightColor='#ffffff'
+            darkColor='#ffffff'
+            className='text-sm leading-relaxed'>
+            {description}
+          </ThemedText>
+        </View>
+
+        <View className='mb-4'>
+          <ThemedText
+            lightColor='#f97316'
+            darkColor='#f97316'
+            className='font-semibold'>
+            Nivel: intermedio
+          </ThemedText>
+        </View>
+
+        <View className='mb-4 flex-row items-baseline'>
+          <ThemedText
+            lightColor='#ffffff'
+            darkColor='#ffffff'
+            className='font-semibold text-sm'>
+            Ubicación / Sala:
+          </ThemedText>
+          <ThemedText
+            lightColor='#d4d4d4'
+            darkColor='#d4d4d4'
+            className='text-sm ml-1'>
+            Sala B - Planta 2
+          </ThemedText>
+        </View>
+
+        {isCrossfitCompleted ? (
+          <View className='mb-6 items-center'>
+            <View className='flex-row items-center rounded-full px-4 py-2 bg-neutral-800'>
+              <CheckCircleIcon size={18} color='#22c55e' />
+              <ThemedText
+                lightColor='#e5e5e5'
+                darkColor='#e5e5e5'
+                className='ml-2 text-xs font-semibold'>
+                Completado
+              </ThemedText>
+            </View>
+          </View>
+        ) : (
+          <View className='mb-6'>
+            <PrimaryButton
+              title={effectiveFull ? 'Clase llena' : reserved ? 'Cancelar' : 'Reservar'}
+              disabled={effectiveFull}
+              style={{ backgroundColor: effectiveFull ? '#6b7280' : reserved ? '#ef4444' : '#f97316' }}
+              onPress={async () => {
+                if (effectiveFull) {
+                  return;
+                }
+                if (reserved) {
+                  await cancel(id);
+                  return;
+                }
+                const lowerTitle = String(title || '').toLowerCase();
+                const img =
+                  typeof heroSource === 'number'
+                    ? heroSource
+                    : (imageUrl as string | number | undefined);
+                if (lowerTitle === 'yoga flow') {
+                  setForceFull(true);
+                  showToast(
+                    'error',
+                    'Clase llena',
+                    'La clase se llenó mientras la reservabas.'
+                  );
+                  return;
+                }
+                if (lowerTitle === 'crossfit') {
+                  await reserve({
+                    id,
+                    title: String(title || ''),
+                    time: String(time || ''),
+                    instructor: String(instructor || ''),
+                    imageUrl: img,
+                  });
+                  setForceFull(true);
+                  return;
+                }
+                await reserve({
+                  id,
+                  title: String(title || ''),
+                  time: String(time || ''),
+                  instructor: String(instructor || ''),
+                  imageUrl: img,
+                });
+                if (lowerTitle === 'spinning') {
+                  showToast(
+                    'success',
+                    'Clase reservada',
+                    'Su clase ha sido reservada correctamente'
+                  );
+                }
+              }}
+            />
+          </View>
+        )}
+        <View className='items-center justify-center mb-2'>
+          <ThemedText
+            lightColor='#9ca3af'
+            darkColor='#9ca3af'
+            className='italic text-center text-xs'>
+            “Podrás cancelar hasta 2h antes del inicio”
+          </ThemedText>
+        </View>
+      </ScrollView>
+    </ThemedView>
+  );
+}

--- a/app/class-details.tsx
+++ b/app/class-details.tsx
@@ -7,7 +7,7 @@ import { useToast } from '@/hooks/useToast';
 import { Image } from 'expo-image';
 import { useLocalSearchParams } from 'expo-router';
 import React, { useMemo, useState } from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { Modal, ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { CheckCircleIcon, ExclamationCircleIcon, StarIcon } from 'react-native-heroicons/solid';
 
 const styles = StyleSheet.create({
@@ -69,6 +69,7 @@ export default function ClassDetailsScreen() {
   const capNum = Number(capacity ?? 25);
   const occNumInitial = Number(occupied ?? 18);
   const [forceFull, setForceFull] = useState(false);
+  const [showCancelModal, setShowCancelModal] = useState(false);
   const isFullInitial = occNumInitial >= capNum;
   const effectiveFull = isFullInitial || forceFull;
   const occNum = effectiveFull ? capNum : occNumInitial;
@@ -268,7 +269,7 @@ export default function ClassDetailsScreen() {
                   return;
                 }
                 if (reserved) {
-                  await cancel(id);
+                  setShowCancelModal(true);
                   return;
                 }
                 const lowerTitle = String(title || '').toLowerCase();
@@ -294,6 +295,11 @@ export default function ClassDetailsScreen() {
                     imageUrl: img,
                   });
                   setForceFull(true);
+                  showToast(
+                    'success',
+                    'Clase reservada',
+                    'Su clase ha sido reservada correctamente'
+                  );
                   return;
                 }
                 await reserve({
@@ -323,6 +329,62 @@ export default function ClassDetailsScreen() {
           </ThemedText>
         </View>
       </ScrollView>
+
+      <Modal
+        visible={showCancelModal}
+        transparent
+        animationType='fade'
+        onRequestClose={() => setShowCancelModal(false)}>
+        <TouchableOpacity
+          activeOpacity={1}
+          style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'center', alignItems: 'center', paddingHorizontal: 24 }}
+          onPress={() => setShowCancelModal(false)}>
+          <View
+            style={{ backgroundColor: '#ffffff', borderRadius: 24, paddingVertical: 24, paddingHorizontal: 20, width: '100%', maxWidth: 360 }}>
+            <ThemedText
+              lightColor='#111827'
+              darkColor='#ffffff'
+              className='text-xl font-bold text-center mb-2'>
+              ¿Cancelar reserva?
+            </ThemedText>
+            <ThemedText
+              lightColor='#4b5563'
+              darkColor='#9ca3af'
+              className='text-sm text-center mb-6'>
+              Perderás tu cupo en esta clase. ¿Estás seguro?
+            </ThemedText>
+            <View className='gap-3'>
+              <TouchableOpacity
+                activeOpacity={0.8}
+                onPress={async () => {
+                  await cancel(id);
+                  setShowCancelModal(false);
+                }}
+                className='py-3 rounded-2xl items-center'
+                style={{ backgroundColor: '#f97316' }}>
+                <ThemedText
+                  lightColor='#ffffff'
+                  darkColor='#ffffff'
+                  className='text-base font-bold'>
+                  Aceptar
+                </ThemedText>
+              </TouchableOpacity>
+              <TouchableOpacity
+                activeOpacity={0.8}
+                onPress={() => setShowCancelModal(false)}
+                className='py-3 rounded-2xl items-center'
+                style={{ backgroundColor: '#e5e7eb' }}>
+                <ThemedText
+                  lightColor='#111827'
+                  darkColor='#ffffff'
+                  className='text-base font-bold'>
+                  Volver
+                </ThemedText>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </TouchableOpacity>
+      </Modal>
     </ThemedView>
   );
 }

--- a/app/membership-confirm.tsx
+++ b/app/membership-confirm.tsx
@@ -3,6 +3,7 @@ import { ThemedText } from '@/components/themed-text';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useMemo } from 'react';
 import { ScrollView, View } from 'react-native';
+import { CheckCircleIcon } from 'react-native-heroicons/solid';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 interface ConfirmParams {
@@ -139,13 +140,7 @@ export default function MembershipConfirmScreen() {
         {/* Icono y mensaje de éxito */}
         <View className='items-center mb-6'>
           <View className='w-16 h-16 rounded-2xl bg-orange-500 items-center justify-center mb-3'>
-            <ThemedText
-              lightColor='#ffffff'
-              darkColor='#ffffff'
-              className='text-2xl'
-            >
-              ✔
-            </ThemedText>
+            <CheckCircleIcon size={40} color='#ffffff' />
           </View>
           <ThemedText
             lightColor='#ffffff'

--- a/app/membership-entry.tsx
+++ b/app/membership-entry.tsx
@@ -1,0 +1,154 @@
+import { PrimaryButton } from '@/components/PrimaryButton';
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { Image } from 'expo-image';
+import { useRouter } from 'expo-router';
+import React from 'react';
+import { ScrollView, TouchableOpacity, View } from 'react-native';
+import { CreditCardIcon, CubeIcon } from 'react-native-heroicons/solid';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+export default function MembershipEntryScreen() {
+	const router = useRouter();
+
+	return (
+		<SafeAreaView className='flex-1 bg-black'>
+			<ThemedView
+				lightColor='#050816'
+				darkColor='#050816'
+				className='flex-1 px-6 pt-4 pb-4'>
+				<ScrollView showsVerticalScrollIndicator={false}>
+					<View className='items-center mb-4'>
+						<Image
+							source={require('@/assets/images/Component_7.png')}
+							style={{ width: 220, height: 120, marginBottom: 6 }}
+							contentFit='contain'
+						/>
+						<ThemedText
+							lightColor='#f97316'
+							darkColor='#f97316'
+							className='text-sm tracking-[0.18em] mt-1'>
+							¿QUÉ DESEAS ADQUIRIR?
+						</ThemedText>
+					</View>
+
+					<View className='gap-5'>
+						<TouchableOpacity
+								activeOpacity={0.9}
+								className='rounded-3xl px-5 py-4'
+								style={{ backgroundColor: '#f97316' }}
+								onPress={() => {
+									router.push('/memberships');
+								}}>
+							<View className='flex-row items-center mb-3'>
+								<View
+									className='w-8 h-8 rounded-full items-center justify-center mr-3'
+									style={{ backgroundColor: 'rgba(0,0,0,0.12)' }}>
+									<CreditCardIcon size={18} color='#ffffff' />
+								</View>
+								<View className='flex-1'>
+									<ThemedText
+										lightColor='#ffffff'
+										darkColor='#ffffff'
+										className='text-[13px] font-semibold'>
+										COMPRAR UNA MEMBRESÍA
+									</ThemedText>
+									<ThemedText
+										lightColor='#ffffff'
+										darkColor='#ffffff'
+										className='text-[10px] opacity-95'>
+										Accede a todas las instalaciones y servicios del gimnasio.
+									</ThemedText>
+								</View>
+							</View>
+							<View className='ml-1'>
+								<ThemedText
+									lightColor='#ffffff'
+									darkColor='#ffffff'
+									className='text-[9px] mb-1'>
+									• Acceso ilimitado
+								</ThemedText>
+								<ThemedText
+									lightColor='#ffffff'
+									darkColor='#ffffff'
+									className='text-[9px] mb-1'>
+									• Beneficios exclusivos
+								</ThemedText>
+								<ThemedText
+									lightColor='#ffffff'
+									darkColor='#ffffff'
+									className='text-[9px]'>
+									• Descuentos en servicios
+								</ThemedText>
+							</View>
+						</TouchableOpacity>
+
+						<TouchableOpacity
+								activeOpacity={0.9}
+								className='rounded-3xl px-5 py-4'
+								style={{ backgroundColor: '#f97316' }}
+								onPress={() => {
+									router.push({
+										pathname: '/membership-extra',
+										params: {
+											id: 'free-trial',
+											title: 'Free Trial',
+											price: '0',
+										},
+									} as never);
+								}}>
+							<View className='flex-row items-center mb-3'>
+								<View
+									className='w-8 h-8 rounded-full items-center justify-center mr-3'
+									style={{ backgroundColor: 'rgba(0,0,0,0.12)' }}>
+									<CubeIcon size={18} color='#ffffff' />
+								</View>
+								<View className='flex-1'>
+									<ThemedText
+										lightColor='#ffffff'
+										darkColor='#ffffff'
+										className='text-[13px] font-semibold'>
+										COMPRAR UN SERVICIO/PAQUETE
+									</ThemedText>
+									<ThemedText
+										lightColor='#ffffff'
+										darkColor='#ffffff'
+										className='text-[10px] opacity-95'>
+										Adquiere paquetes de clases o servicios específicos.
+									</ThemedText>
+								</View>
+							</View>
+							<View className='ml-1'>
+								<ThemedText
+									lightColor='#ffffff'
+									darkColor='#ffffff'
+									className='text-[9px] mb-1'>
+									• Paquetes de clases
+								</ThemedText>
+								<ThemedText
+									lightColor='#ffffff'
+									darkColor='#ffffff'
+									className='text-[9px] mb-1'>
+									• Entrenamiento personal
+								</ThemedText>
+								<ThemedText
+									lightColor='#ffffff'
+									darkColor='#ffffff'
+									className='text-[9px]'>
+									• Servicios individuales
+								</ThemedText>
+							</View>
+						</TouchableOpacity>
+					</View>
+
+					<View className='mt-10'>
+						<PrimaryButton
+							title='Volver al inicio'
+							onPress={() => router.back()}
+						/>
+					</View>
+				</ScrollView>
+			</ThemedView>
+		</SafeAreaView>
+	);
+}

--- a/app/membership-payment-pagomovil.tsx
+++ b/app/membership-payment-pagomovil.tsx
@@ -1,8 +1,9 @@
 import { PrimaryButton } from '@/components/PrimaryButton';
 import { ThemedText } from '@/components/themed-text';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { ScrollView, TextInput, View } from 'react-native';
+import PhoneInput, { IPhoneInputRef } from 'react-native-international-phone-number';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 interface PaymentParams {
@@ -43,6 +44,7 @@ export default function MembershipPaymentPagoMovilScreen() {
   const [reference, setReference] = useState('');
   const [documentNumber, setDocumentNumber] = useState('');
   const [phone, setPhone] = useState('');
+  const phoneInputRef = useRef<IPhoneInputRef | null>(null);
 
   return (
     <SafeAreaView className='flex-1 bg-black'>
@@ -293,13 +295,34 @@ export default function MembershipPaymentPagoMovilScreen() {
           >
             Teléfono
           </ThemedText>
-          <View className='border border-neutral-700 rounded-md h-12 px-3 justify-center bg-neutral-900'>
-            <TextInput
-              value={phone}
-              onChangeText={setPhone}
-              placeholder='Ingrese su número de teléfono'
-              placeholderTextColor='#6B7280'
-              className='text-white text-base'
+          <View className='border border-neutral-700 rounded-md bg-neutral-900 px-2 py-1 justify-center'>
+            <PhoneInput
+              ref={phoneInputRef}
+              value={phone || ''}
+              onChangePhoneNumber={(phoneNumber) => setPhone(phoneNumber)}
+              defaultCountry='VE'
+              placeholder='Número de teléfono'
+              phoneInputStyles={{
+                container: {
+                  backgroundColor: 'transparent',
+                  borderWidth: 0,
+                  height: 40,
+                },
+                flagContainer: {
+                  backgroundColor: 'transparent',
+                },
+                callingCode: {
+                  color: '#e5e7eb',
+                  fontSize: 14,
+                },
+                input: {
+                  color: '#ffffff',
+                  fontSize: 14,
+                },
+                divider: {
+                  backgroundColor: '#374151',
+                },
+              }}
             />
           </View>
         </View>

--- a/app/membership-payment-transfer.tsx
+++ b/app/membership-payment-transfer.tsx
@@ -1,8 +1,9 @@
 import { PrimaryButton } from '@/components/PrimaryButton';
 import { ThemedText } from '@/components/themed-text';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { ScrollView, TextInput, View } from 'react-native';
+import PhoneInput, { IPhoneInputRef } from 'react-native-international-phone-number';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 interface PaymentParams {
@@ -43,6 +44,7 @@ export default function MembershipPaymentTransferScreen() {
   const [reference, setReference] = useState('');
   const [documentNumber, setDocumentNumber] = useState('');
   const [phone, setPhone] = useState('');
+  const phoneInputRef = useRef<IPhoneInputRef | null>(null);
 
   return (
     <SafeAreaView className='flex-1 bg-black'>
@@ -293,13 +295,34 @@ export default function MembershipPaymentTransferScreen() {
           >
             Teléfono
           </ThemedText>
-          <View className='border border-neutral-700 rounded-md h-12 px-3 justify-center bg-neutral-900'>
-            <TextInput
-              value={phone}
-              onChangeText={setPhone}
-              placeholder='Ingrese su número de teléfono'
-              placeholderTextColor='#6B7280'
-              className='text-white text-base'
+          <View className='border border-neutral-700 rounded-md bg-neutral-900 px-2 py-1 justify-center'>
+            <PhoneInput
+              ref={phoneInputRef}
+              value={phone || ''}
+              onChangePhoneNumber={(phoneNumber) => setPhone(phoneNumber)}
+              defaultCountry='VE'
+              placeholder='Número de teléfono'
+              phoneInputStyles={{
+                container: {
+                  backgroundColor: 'transparent',
+                  borderWidth: 0,
+                  height: 40,
+                },
+                flagContainer: {
+                  backgroundColor: 'transparent',
+                },
+                callingCode: {
+                  color: '#e5e7eb',
+                  fontSize: 14,
+                },
+                input: {
+                  color: '#ffffff',
+                  fontSize: 14,
+                },
+                divider: {
+                  backgroundColor: '#374151',
+                },
+              }}
             />
           </View>
         </View>

--- a/components/ClassCard.tsx
+++ b/components/ClassCard.tsx
@@ -40,8 +40,8 @@ export default function ClassCard({
 		return (
 			<TouchableOpacity
 				onPress={() => onPress(classData)}
-				className='rounded-2xl overflow-hidden mb-4 bg-white'>
-				<View className='h-44 w-full rounded-2xl overflow-hidden'>
+				className='rounded-2xl overflow-hidden mb-4 bg-neutral-900'>
+				<View className='h-40 w-full rounded-2xl overflow-hidden'>
 					<Image
 						source={imageUrl}
 						style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }}
@@ -52,33 +52,51 @@ export default function ClassCard({
 					<View className='absolute inset-0 p-4 justify-between'>
 						<View className='flex-row justify-between items-start'>
 							<View>
-								<ThemedText className='text-white text-xl font-extrabold'>
+								<ThemedText
+									lightColor='#ffffff'
+									darkColor='#ffffff'
+									className='text-xl font-extrabold'>
 									{title}
 								</ThemedText>
-								<ThemedText className='text-white/90 mt-1 font-semibold'>
+								<ThemedText
+									lightColor='#e5e5e5'
+									darkColor='#e5e5e5'
+									className='mt-1 font-semibold'>
 									Today, {time}
 								</ThemedText>
-								<ThemedText className='text-white/80 text-xs mt-1'>
+								<ThemedText
+									lightColor='#d4d4d4'
+									darkColor='#d4d4d4'
+									className='text-xs mt-1'>
 									Disponibilidad
 								</ThemedText>
 							</View>
 							{!!(category || branch) && (
 								<View className='bg-white/20 rounded-full px-3 py-1'>
-									<ThemedText className='text-white text-xs font-semibold'>
+									<ThemedText
+										lightColor='#ffffff'
+										darkColor='#ffffff'
+										className='text-xs font-semibold'>
 										{category || 'categoría'}
 									</ThemedText>
 								</View>
 							)}
 						</View>
 						<View className='flex-row'>
-							<ThemedText className='text-white/80 text-xs'>
+							<ThemedText
+								lightColor='#e5e5e5'
+								darkColor='#e5e5e5'
+								className='text-xs'>
 								{instructor.replace(/^Con\s+/i, '')}
 							</ThemedText>
 						</View>
 					</View>
 					{reserved ? (
 						<View className='absolute top-3 left-3 bg-orange-500 rounded-full px-2 py-1'>
-							<ThemedText className='text-white text-xs font-bold'>
+							<ThemedText
+								lightColor='#ffffff'
+								darkColor='#ffffff'
+								className='text-xs font-bold'>
 								Reservado
 							</ThemedText>
 						</View>

--- a/components/PrimaryButton.tsx
+++ b/components/PrimaryButton.tsx
@@ -4,11 +4,11 @@ interface Props extends TouchableOpacityProps {
 	title: string;
 }
 
-export function PrimaryButton({ title, ...props }: Props) {
+export function PrimaryButton({ title, style, ...props }: Props) {
 	return (
 		<TouchableOpacity
-			className='h-14 w-full items-center justify-center rounded-md'
-			style={{ backgroundColor: '#f97316' }}
+			className='h-12 w-full items-center justify-center rounded-full'
+			style={[{ backgroundColor: '#f97316' }, style]}
 			{...props}>
 			<Text className='text-white text-base font-bold'>{title}</Text>
 		</TouchableOpacity>

--- a/components/auth/training/RoutinesCarousel.tsx
+++ b/components/auth/training/RoutinesCarousel.tsx
@@ -10,20 +10,31 @@ export type RoutineChip = {
 
 export type RoutinesCarouselProps = {
   items: RoutineChip[];
-  onSelect?: (id: string) => void;
+  showTitle?: boolean;
+  titleText?: string;
+  titleColor?: string;
 };
 
-export default function RoutinesCarousel({ items }: RoutinesCarouselProps) {
+export default function RoutinesCarousel({
+  items,
+  showTitle = true,
+  titleText = 'Rutinas',
+  titleColor = '#111827',
+}: RoutinesCarouselProps) {
   return (
     <View style={{ marginBottom: 16 }}>
-      <Text style={{
-        fontFamily: 'BebasNeue-Regular',
-        fontSize: 28,
-        color: '#111827',
-        marginBottom: 8,
-      }}>
-        Rutinas
-      </Text>
+      {showTitle && (
+        <Text
+          style={{
+            fontFamily: 'BebasNeue-Regular',
+            fontSize: 28,
+            color: titleColor,
+            marginBottom: 8,
+          }}
+        >
+          {titleText}
+        </Text>
+      )}
       <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ paddingRight: 8 }}>
         {items.map((it) => (
           <LinearGradient
@@ -40,7 +51,8 @@ export default function RoutinesCarousel({ items }: RoutinesCarouselProps) {
               marginRight: 12,
               alignItems: 'center',
               justifyContent: 'center',
-            }}>
+            }}
+          >
             <View style={{ alignItems: 'center' }}>
               <Image source={it.image} style={{ width: 48, height: 48, tintColor: '#F27F2A', marginBottom: 10 }} resizeMode="contain" />
               <Text style={{ color: '#FFFFFF', fontWeight: '700', textAlign: 'center' }}>{it.label}</Text>

--- a/package-lock.json
+++ b/package-lock.json
@@ -272,6 +272,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
 			"integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/generator": "^7.28.3",
@@ -4073,6 +4074,7 @@
 			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
 			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jest/schemas": "^29.6.3",
 				"@types/istanbul-lib-coverage": "^2.0.0",
@@ -4797,6 +4799,7 @@
 			"resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.19.tgz",
 			"integrity": "sha512-fM7q8di4Q8sp2WUhiUWOe7bEDRyRhbzsKQOd5N2k+lHeCx3UncsRYuw4Q/KN0EovM3wWKqMMmhy/YWuEO04kgw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@react-navigation/core": "^7.13.0",
 				"escape-string-regexp": "^4.0.0",
@@ -5043,7 +5046,6 @@
 			"integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/eslint": "*",
 				"@types/estree": "*"
@@ -5259,6 +5261,7 @@
 			"integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.45.0",
 				"@typescript-eslint/types": "8.45.0",
@@ -5784,7 +5787,6 @@
 			"integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/helper-numbers": "1.13.2",
 				"@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -5795,24 +5797,21 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
 			"integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
 			"devOptional": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-api-error": {
 			"version": "1.13.2",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
 			"integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
 			"devOptional": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-buffer": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
 			"integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
 			"devOptional": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-numbers": {
 			"version": "1.13.2",
@@ -5820,7 +5819,6 @@
 			"integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/floating-point-hex-parser": "1.13.2",
 				"@webassemblyjs/helper-api-error": "1.13.2",
@@ -5832,8 +5830,7 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
 			"integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
 			"devOptional": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-wasm-section": {
 			"version": "1.14.1",
@@ -5841,7 +5838,6 @@
 			"integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@webassemblyjs/helper-buffer": "1.14.1",
@@ -5855,7 +5851,6 @@
 			"integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
@@ -5866,7 +5861,6 @@
 			"integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@xtuc/long": "4.2.2"
 			}
@@ -5876,8 +5870,7 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
 			"integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
 			"devOptional": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/wasm-edit": {
 			"version": "1.14.1",
@@ -5885,7 +5878,6 @@
 			"integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@webassemblyjs/helper-buffer": "1.14.1",
@@ -5903,7 +5895,6 @@
 			"integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -5918,7 +5909,6 @@
 			"integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@webassemblyjs/helper-buffer": "1.14.1",
@@ -5932,7 +5922,6 @@
 			"integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@webassemblyjs/helper-api-error": "1.13.2",
@@ -5948,7 +5937,6 @@
 			"integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@xtuc/long": "4.2.2"
@@ -5968,16 +5956,14 @@
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
 			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
 			"devOptional": true,
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@xtuc/long": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
 			"devOptional": true,
-			"license": "Apache-2.0",
-			"peer": true
+			"license": "Apache-2.0"
 		},
 		"node_modules/abab": {
 			"version": "2.0.6",
@@ -6017,6 +6003,7 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -6041,7 +6028,6 @@
 			"integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10.13.0"
 			},
@@ -6117,7 +6103,6 @@
 			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ajv": "^8.0.0"
 			},
@@ -6136,7 +6121,6 @@
 			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -6153,8 +6137,7 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 			"devOptional": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/anser": {
 			"version": "1.4.10",
@@ -6471,6 +6454,7 @@
 			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
 			"integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jest/transform": "^29.7.0",
 				"@types/babel__core": "^7.1.14",
@@ -6852,6 +6836,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.9",
 				"caniuse-lite": "^1.0.30001746",
@@ -7122,7 +7107,6 @@
 			"integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6.0"
 			}
@@ -8402,8 +8386,7 @@
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
 			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
 			"devOptional": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.1",
@@ -8529,6 +8512,7 @@
 			"integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -8652,6 +8636,7 @@
 			"integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -8867,6 +8852,7 @@
 			"integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@rtsao/scc": "^1.1.0",
 				"array-includes": "^3.1.9",
@@ -9398,7 +9384,6 @@
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.8.x"
 			}
@@ -9529,6 +9514,7 @@
 			"resolved": "https://registry.npmjs.org/expo/-/expo-54.0.23.tgz",
 			"integrity": "sha512-b4uQoiRwQ6nwqsT2709RS15CWYNGF3eJtyr1KyLw9WuMAK7u4jjofkhRiO0+3o1C2NbV+WooyYTOZGubQQMBaQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.20.0",
 				"@expo/cli": "54.0.16",
@@ -9612,6 +9598,7 @@
 			"resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.10.tgz",
 			"integrity": "sha512-Rhtv+X974k0Cahmvx6p7ER5+pNhBC0XbP1lRviL2J1Xl4sT2FBaIuIxF/0I0CbhOsySf0ksqc5caFweAy9Ewiw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@expo/config": "~12.0.10",
 				"@expo/env": "~2.0.7"
@@ -9636,6 +9623,7 @@
 			"resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.9.tgz",
 			"integrity": "sha512-xCoQbR/36qqB6tew/LQ6GWICpaBmHLhg/Loix5Rku/0ZtNaXMJv08M9o1AcrdiGTn/Xf/BnLu6DgS45cWQEHZg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fontfaceobserver": "^2.1.0"
 			},
@@ -9697,6 +9685,7 @@
 			"resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.8.tgz",
 			"integrity": "sha512-MyeMcbFDKhXh4sDD1EHwd0uxFQNAc6VCrwBkNvvvufUsTYFq3glTA9Y8a+x78CPpjNqwNAamu74yIaIz7IEJyg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"expo-constants": "~18.0.8",
 				"invariant": "^2.2.4"
@@ -10444,8 +10433,7 @@
 					"url": "https://opencollective.com/fastify"
 				}
 			],
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/fastq": {
 			"version": "1.19.1",
@@ -10950,8 +10938,7 @@
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
 			"devOptional": true,
-			"license": "BSD-2-Clause",
-			"peer": true
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/global-dirs": {
 			"version": "0.1.1",
@@ -12154,6 +12141,7 @@
 			"integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jest/core": "^29.7.0",
 				"@jest/types": "^29.6.3",
@@ -13315,6 +13303,7 @@
 			"integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
 			}
@@ -14007,7 +13996,6 @@
 			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6.11.5"
 			}
@@ -15759,6 +15747,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.7",
 				"picocolors": "^1.1.1",
@@ -15905,6 +15894,7 @@
 			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -16406,7 +16396,6 @@
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -16449,6 +16438,7 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
 			"integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -16468,6 +16458,7 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
 			"integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.26.0"
 			},
@@ -16498,6 +16489,7 @@
 			"resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.63.0.tgz",
 			"integrity": "sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18.0.0"
 			},
@@ -16520,6 +16512,7 @@
 			"resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
 			"integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jest/create-cache-key-function": "^29.7.0",
 				"@react-native/assets-registry": "0.81.5",
@@ -16902,6 +16895,7 @@
 			"resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
 			"integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@egjs/hammerjs": "^2.0.17",
 				"hoist-non-react-statics": "^3.3.0",
@@ -16977,6 +16971,7 @@
 			"resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.2.tgz",
 			"integrity": "sha512-qzmQiFrvjm62pRBcj97QI9Xckc3EjgHQoY1F2yjktd0kpjhoyePeuTEXjYRCAVIy7IV/1cfeSup34+zFThFoHQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"react-native-is-edge-to-edge": "^1.2.1",
 				"semver": "7.7.2"
@@ -17005,6 +17000,7 @@
 			"resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.1.tgz",
 			"integrity": "sha512-/wJE58HLEAkATzhhX1xSr+fostLsK8Q97EfpfMDKo8jlOc1QKESSX/FQrhk7HhQH/2uSaox4Y86sNaI02kteiA==",
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"react": "*",
 				"react-native": "*"
@@ -17015,6 +17011,7 @@
 			"resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
 			"integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"react-freeze": "^1.0.0",
 				"react-native-is-edge-to-edge": "^1.2.1",
@@ -17030,6 +17027,7 @@
 			"resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.15.0.tgz",
 			"integrity": "sha512-/Wx6F/IZ88B/GcF88bK8K7ZseJDYt+7WGaiggyzLvTowChQ8BM5idmcd4pK+6QJP6a6DmzL2sfOMukFUn/NArg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"css-select": "^5.1.0",
 				"css-tree": "^1.1.3",
@@ -17051,6 +17049,7 @@
 			"resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.1.tgz",
 			"integrity": "sha512-BeNsgwwe4AXUFPAoFU+DKjJ+CVQa3h54zYX77p7GVZrXiiNo3vl03WYDYVEy5R2J2HOPInXtQZB5gmj3vuzrKg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.6",
 				"@react-native/normalize-colors": "^0.74.1",
@@ -17215,6 +17214,7 @@
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
 			"integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -17272,6 +17272,7 @@
 			"integrity": "sha512-hLug9KEXLc8vnU9lDNe2b2rKKDaqrp5gNiES4uyu2Up3FZfZJZmdwLFXlWzdA9gTB/6/cWduSB2K1Lfag2pSvw==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"acorn-loose": "^8.3.0",
 				"neo-async": "^2.6.1",
@@ -17314,6 +17315,7 @@
 			"integrity": "sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"react-is": "^19.1.0",
 				"scheduler": "^0.26.0"
@@ -17849,7 +17851,6 @@
 			"integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
 				"ajv": "^8.9.0",
@@ -17888,7 +17889,6 @@
 			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3"
 			},
@@ -17901,8 +17901,7 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 			"devOptional": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/semver": {
 			"version": "6.3.1",
@@ -17988,7 +17987,6 @@
 			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
 			"devOptional": true,
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"randombytes": "^2.1.0"
 			}
@@ -18876,6 +18874,7 @@
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
 			"integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@alloc/quick-lru": "^5.2.0",
 				"arg": "^5.0.2",
@@ -19032,7 +19031,6 @@
 			"integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jest-worker": "^27.4.5",
@@ -19068,7 +19066,6 @@
 			"integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
@@ -19084,7 +19081,6 @@
 			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -19233,6 +19229,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -19576,6 +19573,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -20187,7 +20185,6 @@
 			"integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
@@ -20217,7 +20214,6 @@
 			"integrity": "sha512-hUtqAR3ZLVEYDEABdBioQCIqSoguHbFn1K7WlPPWSuXmx0031BD73PSE35jKyftdSh4YLDoQNgK4pqBt5Q82MA==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
@@ -20277,7 +20273,6 @@
 			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
 			"devOptional": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^4.1.1"
@@ -20292,7 +20287,6 @@
 			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"devOptional": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -20805,6 +20799,7 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
 			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}


### PR DESCRIPTION
Descripción
Se añadió una nueva pantalla de entrada (/membership-entry) antes del flujo de compra, donde el usuario elige entre comprar una membresía o solo un servicio/paquete. La UI replica el diseño dark/orange con el header VITALFIT y dos tarjetas naranjas.

Motivación
Antes se iba directo a /memberships, sin dejar claro si el usuario quería membresía completa o solo paquetes. Esta pantalla organiza mejor el flujo de compra y hace más clara la decisión.

Cambios realizados

Nueva pantalla membership-entry con logo Component_7, título “¿QUÉ DESEAS ADQUIRIR?” y dos tarjetas:
“COMPRAR UNA MEMBRESÍA” → navega a /memberships.
“COMPRAR UN SERVICIO/PAQUETE” → navega a /membership-extra con el plan gratuito (free-trial) preseleccionado.
Estilos de tipografía ajustados: títulos en negrita; descripciones y bullets más pequeños y en peso normal.
Registro de la ruta membership-entry en 
_layout.tsx
.
Dashboard actualizado para que la MembershipCard, el CTA en modo invitado y los banners que antes iban a /memberships ahora usen /membership-entry como entrada.
Menú de perfil actualizado: el item “Membresía” lleva a /membership-entry.
Cómo probar

Desde Perfil → “Membresía” → debe abrirse la nueva pantalla con logo y dos tarjetas.
Desde el Dashboard (sin membresía) → botón de compra y banners relacionados deben abrir /membership-entry.
En la nueva pantalla:
“COMPRAR UNA MEMBRESÍA” → lleva a /memberships y el flujo de compra funciona normal.
“COMPRAR UN SERVICIO/PAQUETE” → lleva a /membership-extra con id=free-trial, title=Free Trial, price=0.
Verificar que el botón “Volver al inicio” funciona y que no hay efectos secundarios en otros flujos de membresía.
Feedback submitted