### PR TITLE
endpoint clases y reservas

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -3,10 +3,12 @@ import React from 'react';
 import { useTranslation } from 'react-i18next'; // <--- 1. Importamos el hook
 
 import { HapticTab } from '@/components/haptic-tab';
+import { UserProvider } from '@/contexts/UserContext';
+
 import { Dumbbell } from 'lucide-react-native';
 import { View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { CalendarIcon, HomeIcon, UserIcon, UsersIcon } from 'react-native-heroicons/solid';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export default function TabLayout() {
     // 2. Obtenemos la función para traducir
@@ -14,148 +16,150 @@ export default function TabLayout() {
     const insets = useSafeAreaInsets(); 
 
     return (
-        <Tabs
-            screenOptions={{
-                tabBarActiveTintColor: '#f97316',
-                tabBarInactiveTintColor: '#a1a1aa',
-                headerShown: false,
-                tabBarButton: HapticTab,
-                tabBarStyle: {
-                    backgroundColor: '#1f2937',
-                    borderTopWidth: 0,
-                    borderRadius: 0,
-                    marginHorizontal: 0,
-                    height: 60 + insets.bottom,
-                    position: 'absolute',
-                    left: 0,
-                    right: 0,
-                    bottom: 0,
-                    paddingHorizontal: 8,
-                    overflow: 'hidden',
-                    elevation: 0,
-                    paddingBottom: Math.max(insets.bottom, 6),
-                    paddingTop: 0,
-                },
-                tabBarItemStyle: {
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                    height: 60,
-                    paddingVertical: 0,
-                    paddingTop: 0,
-                    paddingBottom: 0,
-                    margin: 0,
-                },
-                tabBarIconStyle: {
-                    marginTop: 0,
-                    marginBottom: 0,
-                },
-                tabBarShowLabel: false, // Tienes los labels ocultos, pero el 'title' se usa para accesibilidad y header si se activara
-                tabBarLabel: () => null,
-            }}>
-            <Tabs.Screen
-                name='dashboard'
-                options={{
-                    title: t('nav.dashboard'), // <--- Traducción: Inicio / Home
-                    tabBarIcon: ({ focused }) => (
-                        <View
-                            style={{
-                                backgroundColor: focused ? '#f97316' : 'transparent',
-                                borderRadius: 12,
-                                width: 44,
-                                height: 44,
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                                marginTop: 16,
-                            }}>
-                            <HomeIcon color={focused ? '#fff' : '#a1a1aa'} size={24} />
-                        </View>
-                    ),
-                }}
-            />
-            <Tabs.Screen
-                name='schedule'
-                options={{
-                    title: t('nav.schedule'), // <--- Traducción: Horarios / Schedule
-                    tabBarIcon: ({ focused }) => (
-                        <View
-                            style={{
-                                backgroundColor: focused ? '#f97316' : 'transparent',
-                                borderRadius: 12,
-                                width: 44,
-                                height: 44,
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                                marginTop: 16,
-                            }}>
-                            <CalendarIcon color={focused ? '#fff' : '#a1a1aa'} size={24} />
-                        </View>
-                    ),
-                }}
-            />
-            <Tabs.Screen
-                name='training'
-                options={{
-                    title: t('nav.training'), // <--- Traducción: Entrenamiento / Training
-                    tabBarIcon: ({ focused }) => (
-                        <View
-                            style={{
-                                backgroundColor: focused ? '#f97316' : 'transparent',
-                                borderRadius: 12,
-                                width: 44,
-                                height: 44,
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                                marginTop: 16,
-                            }}>
-                            <Dumbbell
-                                color={focused ? '#fff' : '#a1a1aa'}
-                                size={24}
-                                strokeWidth={1.5}
-                            />
-                        </View>
-                    ),
-                }}
-            />
-            <Tabs.Screen
-                name='community'
-                options={{
-                    title: t('nav.community'), // <--- Traducción: Comunidad / Community
-                    tabBarIcon: ({ focused }) => (
-                        <View
-                            style={{
-                                backgroundColor: focused ? '#f97316' : 'transparent',
-                                borderRadius: 12,
-                                width: 44,
-                                height: 44,
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                                marginTop: 16,
-                            }}>
-                            <UsersIcon color={focused ? '#fff' : '#a1a1aa'} size={24} />
-                        </View>
-                    ),
-                }}
-            />
-            <Tabs.Screen
-                name='profile'
-                options={{
-                    title: t('nav.profile'), // <--- Traducción: Perfil / Profile
-                    tabBarIcon: ({ focused }) => (
-                        <View
-                            style={{
-                                backgroundColor: focused ? '#f97316' : 'transparent',
-                                borderRadius: 12,
-                                width: 44,
-                                height: 44,
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                                marginTop: 16,
-                            }}>
-                            <UserIcon color={focused ? '#fff' : '#a1a1aa'} size={24} />
-                        </View>
-                    ),
-                }}
-            />
-        </Tabs>
+        <UserProvider>
+            <Tabs
+                screenOptions={{
+                    tabBarActiveTintColor: '#f97316',
+                    tabBarInactiveTintColor: '#a1a1aa',
+                    headerShown: false,
+                    tabBarButton: HapticTab,
+                    tabBarStyle: {
+                        backgroundColor: '#1f2937',
+                        borderTopWidth: 0,
+                        borderRadius: 0,
+                        marginHorizontal: 0,
+                        height: 60 + insets.bottom,
+                        position: 'absolute',
+                        left: 0,
+                        right: 0,
+                        bottom: 0,
+                        paddingHorizontal: 8,
+                        overflow: 'hidden',
+                        elevation: 0,
+                        paddingBottom: Math.max(insets.bottom, 6),
+                        paddingTop: 0,
+                    },
+                    tabBarItemStyle: {
+                        justifyContent: 'center',
+                        alignItems: 'center',
+                        height: 60,
+                        paddingVertical: 0,
+                        paddingTop: 0,
+                        paddingBottom: 0,
+                        margin: 0,
+                    },
+                    tabBarIconStyle: {
+                        marginTop: 0,
+                        marginBottom: 0,
+                    },
+                    tabBarShowLabel: false, // Tienes los labels ocultos, pero el 'title' se usa para accesibilidad y header si se activara
+                    tabBarLabel: () => null,
+                }}>
+                <Tabs.Screen
+                    name='dashboard'
+                    options={{
+                        title: t('nav.dashboard'), // <--- Traducción: Inicio / Home
+                        tabBarIcon: ({ focused }) => (
+                            <View
+                                style={{
+                                    backgroundColor: focused ? '#f97316' : 'transparent',
+                                    borderRadius: 12,
+                                    width: 44,
+                                    height: 44,
+                                    alignItems: 'center',
+                                    justifyContent: 'center',
+                                    marginTop: 16,
+                                }}>
+                                <HomeIcon color={focused ? '#fff' : '#a1a1aa'} size={24} />
+                            </View>
+                        ),
+                    }}
+                />
+                <Tabs.Screen
+                    name='schedule'
+                    options={{
+                        title: t('nav.schedule'), // <--- Traducción: Horarios / Schedule
+                        tabBarIcon: ({ focused }) => (
+                            <View
+                                style={{
+                                    backgroundColor: focused ? '#f97316' : 'transparent',
+                                    borderRadius: 12,
+                                    width: 44,
+                                    height: 44,
+                                    alignItems: 'center',
+                                    justifyContent: 'center',
+                                    marginTop: 16,
+                                }}>
+                                <CalendarIcon color={focused ? '#fff' : '#a1a1aa'} size={24} />
+                            </View>
+                        ),
+                    }}
+                />
+                <Tabs.Screen
+                    name='training'
+                    options={{
+                        title: t('nav.training'), // <--- Traducción: Entrenamiento / Training
+                        tabBarIcon: ({ focused }) => (
+                            <View
+                                style={{
+                                    backgroundColor: focused ? '#f97316' : 'transparent',
+                                    borderRadius: 12,
+                                    width: 44,
+                                    height: 44,
+                                    alignItems: 'center',
+                                    justifyContent: 'center',
+                                    marginTop: 16,
+                                }}>
+                                <Dumbbell
+                                    color={focused ? '#fff' : '#a1a1aa'}
+                                    size={24}
+                                    strokeWidth={1.5}
+                                />
+                            </View>
+                        ),
+                    }}
+                />
+                <Tabs.Screen
+                    name='community'
+                    options={{
+                        title: t('nav.community'), // <--- Traducción: Comunidad / Community
+                        tabBarIcon: ({ focused }) => (
+                            <View
+                                style={{
+                                    backgroundColor: focused ? '#f97316' : 'transparent',
+                                    borderRadius: 12,
+                                    width: 44,
+                                    height: 44,
+                                    alignItems: 'center',
+                                    justifyContent: 'center',
+                                    marginTop: 16,
+                                }}>
+                                <UsersIcon color={focused ? '#fff' : '#a1a1aa'} size={24} />
+                            </View>
+                        ),
+                    }}
+                />
+                <Tabs.Screen
+                    name='profile'
+                    options={{
+                        title: t('nav.profile'), // <--- Traducción: Perfil / Profile
+                        tabBarIcon: ({ focused }) => (
+                            <View
+                                style={{
+                                    backgroundColor: focused ? '#f97316' : 'transparent',
+                                    borderRadius: 12,
+                                    width: 44,
+                                    height: 44,
+                                    alignItems: 'center',
+                                    justifyContent: 'center',
+                                    marginTop: 16,
+                                }}>
+                                <UserIcon color={focused ? '#fff' : '#a1a1aa'} size={24} />
+                            </View>
+                        ),
+                    }}
+                />
+            </Tabs>
+        </UserProvider>
     );
 }

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -8,9 +8,8 @@ import { UpcomingRoutinesSection } from '@/components/auth/dashboard/upcomingrou
 import { UserHeader } from '@/components/auth/dashboard/userheader';
 import WeeklyChallengeBanner from '@/components/auth/dashboard/WeeklyChallengeBanner';
 import { ThemedView } from '@/components/themed-view';
-import vitalFitApi from '@/services/vitalfitSdk';
+import { useUser } from '@/contexts/UserContext';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { isAPIError } from '@vitalfit/sdk';
 import { useFocusEffect, useRouter } from 'expo-router';
 import React, { useEffect, useState } from 'react';
 import { ActivityIndicator, BackHandler, Text as RNText, ScrollView, View } from 'react-native';
@@ -19,8 +18,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 export default function DashboardScreen() {
 	const router = useRouter();
 	const insets = useSafeAreaInsets();
-	const [firstName, setFirstName] = useState<string | null>(null);
-	const [lastName, setLastName] = useState<string | null>(null);
+	const { user, loading: userLoading } = useUser();
 	const [loading, setLoading] = useState(true);
 	const [qrModalVisible, setQrModalVisible] = useState(false);
 	const [userToken, setUserToken] = useState<string>('');
@@ -28,57 +26,23 @@ export default function DashboardScreen() {
 
 
 	useEffect(() => {
-		 
-		const fetchUser = async () => {
+		const init = async () => {
 			try {
-				await new Promise(resolve => setTimeout(resolve, 3000));
-				// Intentar obtener el token con retry logic
-				let token = await AsyncStorage.getItem('token');
-
-				// Si no hay token, esperar y reintentar
+				const token = await AsyncStorage.getItem('token');
 				if (!token) {
-					console.log('Token no encontrado en primer intento, esperando...');
-					await new Promise(resolve => setTimeout(resolve, 500));
-					token = await AsyncStorage.getItem('token');
-				}
-
-				// Si aún no hay token, intentar una vez más
-				if (!token) {
-					console.log('Token no encontrado en segundo intento, esperando...');
-					await new Promise(resolve => setTimeout(resolve, 500));
-					token = await AsyncStorage.getItem('token');
-				}
-
-				if (!token) {
-					console.error('No se encontró token en AsyncStorage después de reintentar');
+					console.error('No se encontró token en AsyncStorage');
 					router.replace('/(auth)/login');
 					return;
 				}
 
-				console.log('Token encontrado en AsyncStorage');
 				setUserToken(token);
-
-				const userData = await vitalFitApi.user.WhoAmI(token);
-				setFirstName(userData?.user?.first_name || 'Usuario');
-				setLastName(userData?.user?.last_name || null);
-				console.log('Datos del usuario obtenidos correctamente');
-			} catch (error: unknown) {
-				let errorMessage = 'Ocurrió un error inesperado al obtener los datos del usuario.';
-				if (isAPIError(error)) {
-					errorMessage = error.messages.join(', ');
-				} else if (error instanceof Error) {
-					errorMessage = error.message;
-				}
-				console.error('Error en la solicitud whoami:', errorMessage);
-				router.replace('/(auth)/login');
 			} finally {
 				setLoading(false);
 			}
 		};
 
-		fetchUser();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+		init();
+	}, [router]);
 
 	useFocusEffect(
 		React.useCallback(() => {
@@ -143,7 +107,7 @@ export default function DashboardScreen() {
 		},
 	];
 
-	if (loading) {
+	if (loading || userLoading) {
 		return (
 			<ThemedView className='flex-1 justify-center items-center bg-white dark:bg-neutral-950'>
 				<ActivityIndicator size='large' color='#F27F2A' />
@@ -151,9 +115,11 @@ export default function DashboardScreen() {
 		);
 	}
 
-	const displayName = lastName
-		? `${firstName ?? 'Usuario'} ${lastName}`
-		: firstName ?? 'Usuario';
+	const displayName = user
+		? user.lastName
+			? `${user.firstName || 'Usuario'} ${user.lastName}`
+			: user.firstName || 'Usuario'
+		: 'Usuario';
 
 	return (
 		<ThemedView className='flex-1 bg-white dark:bg-neutral-950'>

--- a/app/(tabs)/profile/index.tsx
+++ b/app/(tabs)/profile/index.tsx
@@ -1,10 +1,9 @@
 import { ClientQRModal } from '@/components/client/ClientQRModal';
-import vitalFitApi from '@/services/vitalfitSdk';
+import { useUser } from '@/contexts/UserContext';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { isAPIError } from '@vitalfit/sdk';
 import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { ActivityIndicator, Modal, ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import {
   ArrowRightOnRectangleIcon,
@@ -22,39 +21,9 @@ import {
 
 export default function ProfileScreen() {
   const router = useRouter();
-  const [loading, setLoading] = useState(true);
-  const [firstName, setFirstName] = useState<string | null>(null);
-  const [lastName, setLastName] = useState<string | null>(null);
+  const { user, loading } = useUser();
   const [qrModalVisible, setQrModalVisible] = useState(false);
   const [logoutModalVisible, setLogoutModalVisible] = useState(false);
-
-  useEffect(() => {
-    const fetchUser = async () => {
-      try {
-        const token = await AsyncStorage.getItem('token');
-        if (!token) {
-          console.error('No se encontró token en AsyncStorage');
-          return;
-        }
-
-        const userData = await vitalFitApi.user.WhoAmI(token);
-        setFirstName(userData?.user?.first_name || 'Cliente');
-        setLastName(userData?.user?.last_name || '');
-      } catch (error: unknown) {
-        let errorMessage = 'Ocurrió un error inesperado al obtener los datos del usuario.';
-        if (isAPIError(error)) {
-          errorMessage = error.messages.join(', ');
-        } else if (error instanceof Error) {
-          errorMessage = error.message;
-        }
-        console.error('Error en la solicitud whoami (Perfil cliente):', errorMessage);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchUser();
-  }, []);
 
   if (loading) {
     return (
@@ -64,7 +33,11 @@ export default function ProfileScreen() {
     );
   }
 
-  const displayName = lastName ? `${firstName ?? 'Cliente'} ${lastName}` : firstName ?? 'Cliente';
+  const displayName = user
+    ? user.lastName
+      ? `${user.firstName || 'Cliente'} ${user.lastName}`
+      : user.firstName || 'Cliente'
+    : 'Cliente';
 
   const handleConfirmLogout = async () => {
     try {
@@ -198,7 +171,7 @@ export default function ProfileScreen() {
           activeOpacity={0.8}
           className="w-full flex-row items-center justify-between rounded-2xl bg-white border border-[#e5e7eb] px-4 py-3 mb-3"
           onPress={() => {
-            router.push('/profile/settings');
+            router.push('/profile/profile-settings');
           }}
         >
           <View className="flex-row items-center">

--- a/app/(tabs)/profile/my-profile.tsx
+++ b/app/(tabs)/profile/my-profile.tsx
@@ -1,7 +1,9 @@
 import { StyledTextInput } from '@/components/StyledTextInput';
 import { ThemedView } from '@/components/themed-view';
 import { ToastNotification } from '@/components/ToastNotification';
+import { useUser } from '@/contexts/UserContext';
 import vitalFitApi from '@/services/vitalfitSdk';
+
 import { zodResolver } from '@hookform/resolvers/zod';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import DateTimePicker from '@react-native-community/datetimepicker';
@@ -68,6 +70,8 @@ type ProfileFormData = z.infer<typeof ProfileSchema>;
 
 export default function MyProfileScreen() {
     const router = useRouter();
+    const { user, updateLocalUser } = useUser();
+
     const [loading, setLoading] = useState(true);
     const [isEditing, setIsEditing] = useState(false);
     const [saving, setSaving] = useState(false);
@@ -113,61 +117,32 @@ export default function MyProfileScreen() {
     });
 
     useEffect(() => {
-        const fetchUser = async () => {
-            try {
-                const token = await AsyncStorage.getItem('token');
-                if (!token) {
-                    console.error('No se encontró token en AsyncStorage');
-                    setLoading(false);
-                    return;
-                }
+        if (!user) {
+            setLoading(false);
+            return;
+        }
 
-                const userData = await vitalFitApi.user.WhoAmI(token);
-                const apiUserId = userData?.user?.user_id || '';
-                const apiFirstName = userData?.user?.first_name || '';
-                const apiLastName = userData?.user?.last_name || '';
-                const apiEmail = userData?.user?.email || '';
-                const apiPhone = userData?.user?.phone || '';
-                const apiDocumentId = userData?.user?.identity_document || '';
-                const apiBirthDate = userData?.user?.birth_date || '';
-                const apiGender = userData?.user?.gender || '';
+        setUserId(user.userId);
+        setFirstName(user.firstName);
+        setLastName(user.lastName);
+        setEmail(user.email);
+        setPhone(user.phone);
+        setDocumentId(user.identityDocument);
+        setGender(user.gender);
 
-                const normalizedGender = apiGender === 'male' ? 'M' : apiGender === 'female' ? 'F' : '';
+        if (user.birthDate) {
+            const parsedDate = new Date(user.birthDate);
+            setBirthDate(format(parsedDate, 'yyyy-MM-dd'));
+        }
 
-                setUserId(apiUserId);
-                setFirstName(apiFirstName);
-                setLastName(apiLastName);
-                setEmail(apiEmail);
-                setPhone(apiPhone);
-                setDocumentId(apiDocumentId);
-                setGender(normalizedGender);
-                
-                if (apiBirthDate) {
-                    const parsedDate = new Date(apiBirthDate);
-                    setBirthDate(format(parsedDate, 'yyyy-MM-dd'));
-                }
-
-                setValue('firstName', apiFirstName);
-                setValue('lastName', apiLastName);
-                setValue('documentId', apiDocumentId);
-                setValue('birthDate', apiBirthDate);
-                setValue('phone', apiPhone);
-                setValue('gender', normalizedGender);
-            } catch (error: unknown) {
-                let errorMessage = 'Ocurrió un error inesperado al obtener los datos del usuario.';
-                if (isAPIError(error)) {
-                    errorMessage = error.messages.join(', ');
-                } else if (error instanceof Error) {
-                    errorMessage = error.message;
-                }
-                console.error('Error en WhoAmI (Perfil personal cliente):', errorMessage);
-            } finally {
-                setLoading(false);
-            }
-        };
-
-        fetchUser();
-    }, [setValue]);
+        setValue('firstName', user.firstName);
+        setValue('lastName', user.lastName);
+        setValue('documentId', user.identityDocument);
+        setValue('birthDate', user.birthDate);
+        setValue('phone', user.phone);
+        setValue('gender', user.gender);
+        setLoading(false);
+    }, [setValue, user]);
 
     const onSubmit = async (data: ProfileFormData) => {
         setSaving(true);
@@ -220,6 +195,14 @@ export default function MyProfileScreen() {
             setDocumentId(data.documentId);
             setPhone(data.phone || '');
             setGender(data.gender);
+            updateLocalUser({
+                firstName: data.firstName,
+                lastName: data.lastName,
+                identityDocument: data.documentId,
+                phone: data.phone || '',
+                gender: data.gender,
+                birthDate: data.birthDate,
+            });
 
             if (data.birthDate) {
                 const date = new Date(data.birthDate);

--- a/app/(tabs)/schedule.tsx
+++ b/app/(tabs)/schedule.tsx
@@ -2,54 +2,17 @@ import { MonthCalendar } from '@/components/auth/dashboard/monthcalendar';
 import { WeekCalendar } from '@/components/auth/dashboard/weekcalendar';
 import RoutinesCarousel, { RoutineChip } from '@/components/auth/training/RoutinesCarousel';
 import ClassCard from '@/components/ClassCard';
-import Dropdown from '@/components/Dropdown';
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
 import { useReservations } from '@/contexts/reservations';
+import vitalFitApi from '@/services/vitalfitSdk';
+import { Ionicons } from '@expo/vector-icons';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useFocusEffect } from '@react-navigation/native';
 import { useRouter } from 'expo-router';
-import React, { useState } from 'react';
-import { Image, Pressable, ScrollView, View } from 'react-native';
+import React, { useCallback, useEffect, useState } from 'react';
+import { ActivityIndicator, Image, Pressable, ScrollView, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-
-const classes = [
-    {
-        time: '12:00 PM',
-        title: 'Zumba',
-        instructor: 'Con Laura Torres',
-        branch: 'Sucursal Sur',
-        imageUrl: require('@/assets/images/zumba-w.jpg'),
-        capacity: 25,
-        occupied: 18,
-    },
-    {
-        time: '11:00 AM',
-        title: 'Spinning',
-        instructor: 'Con Carlos Mendoza',
-        branch: 'Sucursal Norte',
-        imageUrl: require('@/assets/images/spinning-w.jpg'),
-        capacity: 25,
-        occupied: 22,
-    },
-    {
-        time: '10:00 AM',
-        title: 'Yoga Flow',
-        instructor: 'Con Sofia Ramirez',
-        branch: 'Sucursal Centro',
-        imageUrl: require('@/assets/images/yoga-w.jpg'),
-        capacity: 25,
-        occupied: 18,
-    },
-    // Full class example
-    {
-        time: '07:00 AM',
-        title: 'Crossfit',
-        instructor: 'Con Laura Torres',
-        branch: 'Sucursal Sur',
-        imageUrl: require('@/assets/images/crossfit-w.jpg'),
-        capacity: 25,
-        occupied: 24,
-    },
-];
 
 const exploreRoutineChips: RoutineChip[] = [
     { id: 'yoga', label: 'Yoga', image: require('@/assets/images/yoga (2).png') },
@@ -58,70 +21,461 @@ const exploreRoutineChips: RoutineChip[] = [
     { id: 'pilates', label: 'Pilates', image: require('@/assets/images/pilates.png') },
 ];
 
-type Reservation = {
+const PAGE_SIZE = 8;
+
+type BranchItem = {
+    branch_id: string;
+    name: string;
+};
+
+type ClassItem = {
+    classId: string;
+    serviceId: string;
+    instructorId: string;
+    startsAt: string;
+    endsAt: string;
     time: string;
     title: string;
     instructor: string;
     branch: string;
     imageUrl: string | number;
-    status: 'assisted' | 'absent' | 'cancelled';
     capacity: number;
     occupied: number;
 };
 
-const reservations: Reservation[] = [
-    {
-        time: '10:00 AM',
-        title: 'Yoga Flow',
-        instructor: 'Con Sofia Ramirez',
-        branch: 'Sucursal Centro',
-        imageUrl: require('@/assets/images/yoga-w.jpg'),
-        status: 'assisted',
-        capacity: 25,
-        occupied: 18,
-    },
-    {
-        time: '11:00 AM',
-        title: 'Spinning',
-        instructor: 'Con Carlos Mendoza',
-        branch: 'Sucursal Norte',
-        imageUrl: require('@/assets/images/spinning-w.jpg'),
-        status: 'cancelled',
-        capacity: 25,
-        occupied: 22,
-    },
-    {
-        time: '07:00 AM',
-        title: 'Crossfit',
-        instructor: 'Con Laura Torres',
-        branch: 'Sucursal Sur',
-        imageUrl: require('@/assets/images/crossfit-w.jpg'),
-        status: 'assisted',
-        capacity: 25,
-        occupied: 23,
-    },
-];
+type BookingItem = {
+    bookingId: string;
+    classId: string;
+    serviceId: string;
+    instructorId: string;
+    time: string;
+    title: string;
+    instructor: string;
+    branch: string;
+    imageUrl: string | number;
+    capacity: number;
+    occupied: number;
+};
+
+type ApiServiceImage = {
+    image_url?: string;
+    is_primary?: boolean;
+};
+
+type ApiService = {
+    name?: string;
+    service_name?: string;
+    title?: string;
+    display_name?: string;
+    images?: ApiServiceImage[];
+};
+
+type ApiInstructor = {
+    name?: string;
+    first_name?: string;
+    last_name?: string;
+};
+
+type ApiScheduleItem = {
+    branch_id?: string;
+    class_id?: string;
+    classId?: string;
+    ends_at?: string;
+    endsAt?: string;
+    instructor_id?: string;
+    instructorId?: string;
+    is_visible?: boolean;
+    max_capacity?: number;
+    notes?: string;
+    service_id?: string;
+    serviceId?: string;
+    starts_at?: string;
+    startsAt?: string;
+    branch_name?: string;
+    service_name?: string;
+    name?: string;
+    occupied?: number;
+    booking_id?: string;
+    id?: string;
+};
+
+type ApiBookingItem = {
+    class_id?: string;
+    classId?: string;
+    booking_id?: string;
+    id?: string;
+};
 
 export default function HorariosScreen() {
     const router = useRouter();
     const [activeTab, setActiveTab] = useState<'classes' | 'reservas' | 'explorar'>('classes');
     const { isReserved } = useReservations();
+    const [branches, setBranches] = useState<BranchItem[]>([]);
+    const [selectedBranchId, setSelectedBranchId] = useState<string>('');
+    const [loadingBranches, setLoadingBranches] = useState(true);
+    const [branchMenuVisible, setBranchMenuVisible] = useState(false);
+    const [classes, setClasses] = useState<ClassItem[]>([]);
+    const [loadingClasses, setLoadingClasses] = useState(false);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+    const [bookings, setBookings] = useState<BookingItem[]>([]);
+    const [loadingBookings, setLoadingBookings] = useState(false);
+    const [bookingsError, setBookingsError] = useState<string | null>(null);
+    const [visibleBookingsCount, setVisibleBookingsCount] = useState(PAGE_SIZE);
+    const [refreshKey, setRefreshKey] = useState(0);
+
+    useEffect(() => {
+        const initBranches = async () => {
+            try {
+                const token = await AsyncStorage.getItem('token');
+                const response = await vitalFitApi.public.getBranchMap(token || '');
+                const data = (response as { data?: BranchItem[] }).data || [];
+
+                setBranches(data);
+                if (data.length > 0 && !selectedBranchId) {
+                    setSelectedBranchId(data[0].branch_id);
+                }
+            } catch (error) {
+                console.error('Error cargando sucursales en Schedule:', error);
+            } finally {
+                setLoadingBranches(false);
+            }
+        };
+
+        void initBranches();
+    }, [selectedBranchId]);
+
+    useFocusEffect(
+        useCallback(() => {
+            setRefreshKey((prev) => prev + 1);
+        }, []),
+    );
+
+    useEffect(() => {
+        const loadClasses = async () => {
+            if (!selectedBranchId) {
+                setClasses([]);
+                return;
+            }
+
+            setLoadingClasses(true);
+            setErrorMessage(null);
+            try {
+                const token = await AsyncStorage.getItem('token');
+
+                const response = await vitalFitApi.client.get({
+                    url: `/branches/${selectedBranchId}/schedule`,
+                    jwt: token || undefined,
+                });
+
+                const raw = (response as { data?: ApiScheduleItem[] } | ApiScheduleItem[] | undefined) ?? [];
+                const itemsFromApi = Array.isArray((raw as { data?: ApiScheduleItem[] }).data)
+                    ? (raw as { data?: ApiScheduleItem[] }).data
+                    : (raw as ApiScheduleItem[]);
+                const items: ApiScheduleItem[] = Array.isArray(itemsFromApi) ? itemsFromApi : [];
+
+                const serviceImageMap: Record<string, string> = {};
+                const serviceNameMap: Record<string, string> = {};
+                const uniqueServiceIds: string[] = Array.from(
+                    new Set(
+                        items
+                            .map((item) => item.service_id || item.serviceId)
+                            .filter((value): value is string => Boolean(value)),
+                    ),
+                );
+
+                for (const sid of uniqueServiceIds) {
+                    try {
+                        const serviceResp = await vitalFitApi.client.get({
+                            url: `/services/${String(sid)}`,
+                            jwt: token || undefined,
+                        });
+                        const s =
+                            (serviceResp as { data?: ApiService }).data ?? (serviceResp as ApiService | undefined);
+                        const serviceName =
+                            (s && (s.name || s.service_name || s.title || s.display_name)) || 'Clase';
+                        serviceNameMap[String(sid)] = serviceName;
+                        const images: ApiServiceImage[] = Array.isArray(s?.images) ? s.images : [];
+
+                        if (Array.isArray(images) && images.length > 0) {
+                            const primary = images.find((img) => img.is_primary) ?? images[0];
+                            if (primary?.image_url) {
+                                serviceImageMap[String(sid)] = primary.image_url;
+                            }
+                        }
+                    } catch (error) {
+                        console.error('Error cargando servicio en Schedule:', error);
+                    }
+                }
+
+                const instructorMap: Record<string, string> = {};
+                const uniqueInstructorIds: string[] = Array.from(
+                    new Set(
+                        items
+                            .map((item) => item.instructor_id || item.instructorId)
+                            .filter((value): value is string => Boolean(value)),
+                    ),
+                );
+
+                for (const iid of uniqueInstructorIds) {
+                    try {
+                        const instResp = await vitalFitApi.client.get({
+                            url: `/instructor/${String(iid)}`,
+                            jwt: token || undefined,
+                        });
+                        const inst =
+                            (instResp as { data?: ApiInstructor }).data ??
+                            (instResp as ApiInstructor | undefined);
+
+                        const fullName =
+                            inst?.name ||
+                            [inst?.first_name, inst?.last_name]
+                                .filter((part: string | undefined) => !!part)
+                                .join(' ');
+                        if (fullName) {
+                            instructorMap[String(iid)] = fullName;
+                        }
+                    } catch (error) {
+                        console.error('Error cargando instructor en Schedule:', error);
+                    }
+                }
+
+                const mapped: ClassItem[] = items.map((item) => {
+                    const startsAt = item.starts_at || item.startsAt || '';
+                    const endsAt = item.ends_at || item.endsAt || '';
+
+                    const extractTime = (value: string) => {
+                        if (!value) return '';
+                        const timePart = value.split('T')[1];
+                        if (!timePart) return '';
+                        return timePart.slice(0, 5);
+                    };
+
+                    const startTime = extractTime(String(startsAt));
+                    const endTime = extractTime(String(endsAt));
+                    const time = endTime ? `${startTime} - ${endTime}` : startTime;
+                    const instructorId = item.instructor_id || item.instructorId;
+                    const instructorName = instructorId ? instructorMap[instructorId] : undefined;
+                    const sid = item.service_id || item.serviceId || '';
+
+                    return {
+                        classId: item.class_id || item.classId || '',
+                        serviceId: sid,
+                        instructorId: instructorId || '',
+                        startsAt: String(startsAt || ''),
+                        endsAt: String(endsAt || ''),
+                        time,
+                        title: serviceNameMap[sid] || item.service_name || item.name || 'Clase',
+                        instructor: instructorName ? `Con ${instructorName}` : 'Instructor',
+                        branch: item.branch_name || '',
+                        imageUrl: serviceImageMap[sid] || require('@/assets/images/rutina.png'),
+                        capacity: item.max_capacity || 0,
+                        occupied: item.occupied || 0,
+                    };
+                });
+
+                setClasses(mapped);
+                setVisibleCount(PAGE_SIZE);
+            } catch (error) {
+                console.error('Error cargando clases en Schedule:', error);
+                setErrorMessage('No se pudieron cargar las clases. Intenta nuevamente.');
+            } finally {
+                setLoadingClasses(false);
+            }
+        };
+
+        void loadClasses();
+    }, [selectedBranchId, refreshKey]);
+
+    useEffect(() => {
+        const loadBookings = async () => {
+            setBookingsError(null);
+            setLoadingBookings(true);
+            try {
+                const token = await AsyncStorage.getItem('token');
+                if (!token || !selectedBranchId) {
+                    setBookings([]);
+                    return;
+                }
+
+                const whoAmI = (await vitalFitApi.user.WhoAmI(token)) as unknown as {
+                    user?: { id?: string; user_id?: string };
+                };
+                const userId = whoAmI?.user?.id || whoAmI?.user?.user_id;
+                if (!userId) {
+                    setBookings([]);
+                    return;
+                }
+
+                const bookingsResp = await vitalFitApi.client.get({
+                    url: `/bookings/client/${String(userId)}`,
+                    jwt: token,
+                });
+
+                const rawBookings = (bookingsResp as { data?: ApiBookingItem[] } | ApiBookingItem[] | undefined) ?? [];
+                const bookingsFromApi = Array.isArray((rawBookings as { data?: ApiBookingItem[] }).data)
+                    ? (rawBookings as { data?: ApiBookingItem[] }).data
+                    : (rawBookings as ApiBookingItem[]);
+                const bookingsItems: ApiBookingItem[] = Array.isArray(bookingsFromApi) ? bookingsFromApi : [];
+
+                const bookingIdByClassId: Record<string, string> = {};
+                bookingsItems.forEach((bk) => {
+                    const cId = bk.class_id || bk.classId;
+                    const bId = bk.booking_id || bk.id;
+
+                    if (cId && bId) {
+                        bookingIdByClassId[String(cId)] = String(bId);
+                    }
+                });
+
+                const response = await vitalFitApi.client.get({
+                    url: `/schedule/branch/${String(selectedBranchId)}/client/${String(userId)}`,
+                    jwt: token,
+                });
+
+                const raw = (response as { data?: ApiScheduleItem[] } | ApiScheduleItem[] | undefined) ?? [];
+                const itemsFromApi = Array.isArray((raw as { data?: ApiScheduleItem[] }).data)
+                    ? (raw as { data?: ApiScheduleItem[] }).data
+                    : (raw as ApiScheduleItem[]);
+                const items: ApiScheduleItem[] = Array.isArray(itemsFromApi) ? itemsFromApi : [];
+
+                const serviceImageMap: Record<string, string> = {};
+                const serviceNameMap: Record<string, string> = {};
+                const uniqueServiceIds: string[] = Array.from(
+                    new Set(
+                        items
+                            .map((item) => item.service_id || item.serviceId)
+                            .filter((value): value is string => Boolean(value)),
+                    ),
+                );
+
+                for (const sid of uniqueServiceIds) {
+                    try {
+                        const serviceResp = await vitalFitApi.client.get({
+                            url: `/services/${String(sid)}`,
+                            jwt: token,
+                        });
+                        const s =
+                            (serviceResp as { data?: ApiService }).data ?? (serviceResp as ApiService | undefined);
+
+                        const serviceName =
+                            (s && (s.name || s.service_name || s.title || s.display_name)) || 'Clase';
+                        serviceNameMap[String(sid)] = serviceName;
+                        const images: ApiServiceImage[] = Array.isArray(s?.images) ? s.images : [];
+
+                        if (Array.isArray(images) && images.length > 0) {
+                            const primary = images.find((img) => img.is_primary) ?? images[0];
+                            if (primary?.image_url) {
+                                serviceImageMap[String(sid)] = primary.image_url;
+                            }
+                        }
+                    } catch (error) {
+                        console.error('Error cargando servicio para reservas:', error);
+                    }
+                }
+
+                const instructorMap: Record<string, string> = {};
+                const uniqueInstructorIds: string[] = Array.from(
+                    new Set(
+                        items
+                            .map((item) => item.instructor_id || item.instructorId)
+                            .filter((value): value is string => Boolean(value)),
+                    ),
+                );
+
+                for (const iid of uniqueInstructorIds) {
+                    try {
+                        const instResp = await vitalFitApi.client.get({
+                            url: `/instructor/${String(iid)}`,
+                            jwt: token,
+                        });
+                        const inst =
+                            (instResp as { data?: ApiInstructor }).data ??
+                            (instResp as ApiInstructor | undefined);
+
+                        const fullName =
+                            inst?.name ||
+                            [inst?.first_name, inst?.last_name]
+                                .filter((part: string | undefined) => !!part)
+                                .join(' ');
+                        if (fullName) {
+                            instructorMap[String(iid)] = fullName;
+                        }
+                    } catch (error) {
+                        console.error('Error cargando instructor para reservas:', error);
+                    }
+                }
+
+                const mappedBookings: BookingItem[] = items.map((item) => {
+                    const startsAt = item.starts_at || item.startsAt || '';
+                    const endsAt = item.ends_at || item.endsAt || '';
+
+                    const extractTime = (value: string) => {
+                        if (!value) return '';
+                        const timePart = String(value).split('T')[1];
+                        if (!timePart) return '';
+                        return timePart.slice(0, 5);
+                    };
+
+                    const startTime = extractTime(String(startsAt));
+                    const endTime = extractTime(String(endsAt));
+                    const time = endTime ? `${startTime} - ${endTime}` : startTime;
+
+                    const sid = item.service_id || item.serviceId || '';
+                    const instructorId = item.instructor_id || item.instructorId || '';
+
+                    const classId = item.class_id || item.classId || '';
+                    const bookingId = bookingIdByClassId[String(classId)] || item.booking_id || item.id || '';
+
+                    const title = serviceNameMap[String(sid)] || item.service_name || 'Clase';
+
+                    const instructorNameFromMap = instructorId ? instructorMap[String(instructorId)] : undefined;
+
+                    return {
+                        bookingId,
+                        classId,
+                        serviceId: sid,
+                        instructorId,
+                        time,
+                        title,
+                        instructor: instructorNameFromMap ? `Con ${instructorNameFromMap}` : 'Instructor',
+                        branch: item.branch_name || '',
+                        imageUrl: serviceImageMap[String(sid)] || require('@/assets/images/rutina.png'),
+                        capacity: item.max_capacity || 0,
+                        occupied: item.occupied || 0,
+                    };
+                });
+
+                setBookings(mappedBookings);
+                setVisibleBookingsCount(PAGE_SIZE);
+            } catch (error) {
+                console.error('Error cargando reservas del cliente:', error);
+                setBookingsError('No se pudieron cargar tus reservas. Intenta nuevamente.');
+            } finally {
+                setLoadingBookings(false);
+            }
+        };
+
+        if (activeTab === 'reservas') {
+            void loadBookings();
+        }
+    }, [activeTab, selectedBranchId, refreshKey]);
 
     return (
         <ThemedView lightColor='#FFFFFF' darkColor='#050816' style={{ flex: 1 }}>
             <SafeAreaView style={{ flex: 1 }} edges={['top', 'left', 'right']}>
                 <ScrollView
                     showsVerticalScrollIndicator={false}
-                    contentContainerStyle={{ paddingHorizontal: 16, paddingTop: 24, paddingBottom: 80 }}>
-                    {/* Logo como en training.tsx */}
+                    contentContainerStyle={{ paddingHorizontal: 16, paddingTop: 24, paddingBottom: 80 }}
+                >
                     <View className='items-center mb-6'>
+
                         <Image
                             source={require('@/assets/images/Frame.png')}
                             style={{ width: 150, height: 50, resizeMode: 'contain' }}
                         />
                     </View>
 
-                    {/* Título CALENDARIO con mismo estilo que "Rutinas" */}
                     <View className='mb-2'>
                         <ThemedText
                             lightColor='#111827'
@@ -136,7 +490,6 @@ export default function HorariosScreen() {
                         {activeTab === 'reservas' ? <MonthCalendar /> : <WeekCalendar />}
                     </View>
 
-                    {/* Tabs grises: Horarios / Reservas / Explorar */}
                     <View className='flex-row mb-6 border rounded-2xl border-neutral-600 bg-neutral-900/90 p-1'>
                         <Pressable
                             onPress={() => setActiveTab('classes')}
@@ -148,7 +501,8 @@ export default function HorariosScreen() {
                             <ThemedText
                                 lightColor={activeTab === 'classes' ? '#ffffff' : '#9ca3af'}
                                 darkColor={activeTab === 'classes' ? '#ffffff' : '#6b7280'}
-                                className='text-base font-semibold'>
+                                className='text-base font-semibold'
+                            >
                                 Horarios
                             </ThemedText>
                         </Pressable>
@@ -162,7 +516,8 @@ export default function HorariosScreen() {
                             <ThemedText
                                 lightColor={activeTab === 'reservas' ? '#ffffff' : '#9ca3af'}
                                 darkColor={activeTab === 'reservas' ? '#ffffff' : '#6b7280'}
-                                className='text-base font-semibold text-center'>
+                                className='text-base font-semibold text-center'
+                            >
                                 Reservas
                             </ThemedText>
                         </Pressable>
@@ -176,14 +531,16 @@ export default function HorariosScreen() {
                             <ThemedText
                                 lightColor={activeTab === 'explorar' ? '#ffffff' : '#6b7280'}
                                 darkColor={activeTab === 'explorar' ? '#ffffff' : '#6b7280'}
-                                className='text-base font-semibold'>
+                                className='text-base font-semibold'
+                            >
                                 Explorar
                             </ThemedText>
                         </Pressable>
                     </View>
 
-                    <View className='mb-6'>
-                        <View className='flex-row items-center justify-between mt-2'>
+                    <View className='mb-6 z-50'>
+                        <View className='flex-row items-center justify-between mt-2 z-50'>
+
                             <ThemedText
                                 lightColor='#111827'
                                 darkColor='#ffffff'
@@ -191,8 +548,58 @@ export default function HorariosScreen() {
                             >
                                 Próximas clases
                             </ThemedText>
-                            <View style={{ width: 120 }}>
-                                <Dropdown label='Filter' onPress={() => {}} />
+
+                            <View style={{ width: 180, zIndex: 100 }}>
+                                <TouchableOpacity
+                                    activeOpacity={0.7}
+                                    onPress={() => setBranchMenuVisible(!branchMenuVisible)}
+                                    className='flex-row items-center justify-between bg-neutral-100 rounded-xl px-4 py-2.5 border border-neutral-200'
+                                >
+                                    <ThemedText className='text-sm font-semibold text-neutral-800' numberOfLines={1}>
+                                        {loadingBranches
+                                            ? 'Cargando...'
+                                            : branches.find((b) => b.branch_id === selectedBranchId)?.name || 'Seleccionar'}
+                                    </ThemedText>
+                                    <Ionicons
+                                        name={branchMenuVisible ? 'chevron-up' : 'chevron-down'}
+                                        size={16}
+                                        color='#4b5563'
+                                    />
+                                </TouchableOpacity>
+
+                                {branchMenuVisible && (
+                                    <View className='absolute top-12 left-0 right-0 bg-white rounded-xl shadow-lg border border-neutral-200 py-2 z-50'>
+                                        {branches.map((branch) => {
+                                            const isSelected = branch.branch_id === selectedBranchId;
+                                            return (
+                                                <TouchableOpacity
+                                                    key={branch.branch_id}
+                                                    className='px-4 py-2'
+                                                    onPress={() => {
+                                                        setSelectedBranchId(branch.branch_id);
+                                                        setBranchMenuVisible(false);
+                                                    }}
+                                                >
+                                                    <ThemedText
+                                                        style={{
+                                                            fontSize: isSelected ? 16 : 13,
+                                                            fontWeight: isSelected ? '800' : '400',
+                                                            color: isSelected ? '#f97316' : '#111827',
+                                                        }}
+                                                        numberOfLines={1}
+                                                    >
+                                                        {branch.name}
+                                                    </ThemedText>
+                                                </TouchableOpacity>
+                                            );
+                                        })}
+                                        {branches.length === 0 && (
+                                            <View className='px-4 py-3'>
+                                                <ThemedText className='text-sm text-neutral-400'>Sin sedes</ThemedText>
+                                            </View>
+                                        )}
+                                    </View>
+                                )}
                             </View>
                         </View>
                     </View>
@@ -205,16 +612,32 @@ export default function HorariosScreen() {
 
                     {activeTab === 'classes' && (
                         <View>
-                            {classes.map((classItem, index) => (
+                            {loadingClasses && (
+                                <View className='items-center py-4'>
+                                    <ActivityIndicator size='small' color='#f97316' />
+                                </View>
+                            )}
+                            {!loadingClasses && errorMessage && (
+                                <ThemedText className='text-center text-sm text-red-500 mb-4'>{errorMessage}</ThemedText>
+                            )}
+                            {!loadingClasses && !errorMessage && classes.length === 0 && selectedBranchId && (
+                                <ThemedText className='text-center text-sm text-neutral-500 mb-4'>
+                                    No hay clases programadas para esta sede.
+                                </ThemedText>
+                            )}
+                            {classes.slice(0, visibleCount).map((classItem, index) => (
                                 <ClassCard
-                                    key={index}
+                                    key={classItem.classId || index.toString()}
                                     time={classItem.time}
                                     title={classItem.title}
                                     instructor={classItem.instructor}
                                     branch={classItem.branch}
                                     imageUrl={classItem.imageUrl}
                                     variant='overlay'
-                                    category={'categoría'}
+                                    category={`Disponibles: ${Math.max(
+                                        (classItem.capacity || 0) - (classItem.occupied || 0),
+                                        0,
+                                    )} de ${classItem.capacity || 0}`}
                                     reserved={isReserved(`${classItem.title}|${classItem.time}`)}
                                     onPress={(classData) => {
                                         router.push({
@@ -223,73 +646,107 @@ export default function HorariosScreen() {
                                                 ...classData,
                                                 capacity: String(classItem.capacity),
                                                 occupied: String(classItem.occupied),
+                                                classId: classItem.classId,
+                                                serviceId: classItem.serviceId,
+                                                instructorId: classItem.instructorId,
                                             },
                                         });
                                     }}
                                 />
                             ))}
+                            {!loadingClasses &&
+                                !errorMessage &&
+                                classes.length > visibleCount && (
+                                    <View className='items-center mt-2 mb-4'>
+                                        <Pressable
+                                            onPress={() =>
+                                                setVisibleCount((prev) =>
+                                                    Math.min(prev + PAGE_SIZE, classes.length),
+                                                )
+                                            }
+                                            className='px-4 py-2 rounded-full border border-orange-500'
+                                        >
+                                            <ThemedText className='text-sm font-semibold text-orange-500'>
+                                                Cargar más
+                                            </ThemedText>
+                                        </Pressable>
+                                    </View>
+                                )}
                         </View>
                     )}
 
                     {activeTab === 'reservas' && (
                         <View>
                             <ThemedText className='text-xl font-bold mb-4'>Mis reservas</ThemedText>
-                            {reservations.map((reservation, index) => (
-                                <ClassCard
-                                    key={index}
-                                    time={reservation.time}
-                                    title={reservation.title}
-                                    instructor={reservation.instructor}
-                                    branch={reservation.branch}
-                                    imageUrl={reservation.imageUrl}
-                                    variant='overlay'
-                                    category={'categoría'}
-                                    reserved={isReserved(`${reservation.title}|${reservation.time}`)}
-                                    onPress={(classData) => {
-                                        router.push({
-                                            pathname: '/class-details',
-                                            params: {
-                                                ...classData,
-                                                capacity: String(reservation.capacity),
-                                                occupied: String(reservation.occupied),
-                                            },
-                                        });
-                                    }}
-                                />
-                            ))}
-                            {reservations.length === 0 && (
+
+                            {loadingBookings && (
+                                <View className='items-center py-4'>
+                                    <ActivityIndicator size='small' color='#f97316' />
+                                </View>
+                            )}
+
+                            {!loadingBookings && bookingsError && (
+                                <ThemedText className='text-center text-sm text-red-500 mb-4'>
+                                    {bookingsError}
+                                </ThemedText>
+                            )}
+
+                            {!loadingBookings && !bookingsError && bookings.length === 0 && (
                                 <ThemedText className='text-neutral-500'>
                                     Aún no tienes reservas.
                                 </ThemedText>
                             )}
-                        </View>
-                    )}
 
-                    {activeTab === 'explorar' && (
-                        <View>
-                            {classes.map((classItem, index) => (
-                                <ClassCard
-                                    key={index}
-                                    time={classItem.time}
-                                    title={classItem.title}
-                                    instructor={classItem.instructor}
-                                    branch={classItem.branch}
-                                    imageUrl={classItem.imageUrl}
-                                    variant='overlay'
-                                    category={'categoría'}
-                                    reserved={isReserved(`${classItem.title}|${classItem.time}`)}
-                                    onPress={(classData) => {
-                                        router.push({
-                                            pathname: '/class-details',
-                                            params: {
-                                                ...classData,
-                                                capacity: String(classItem.capacity),
-                                                occupied: String(classItem.occupied),
-                                            },
-                                        });
-                                    }}
-                                />
-                            ))}
+                            {!loadingBookings && !bookingsError &&
+                                bookings.slice(0, visibleBookingsCount).map((booking) => (
+                                    <ClassCard
+                                        key={booking.bookingId}
+                                        time={booking.time}
+                                        title={booking.title}
+                                        instructor={booking.instructor}
+                                        branch={booking.branch}
+                                        imageUrl={booking.imageUrl}
+                                        variant='overlay'
+                                        category={`Disponibles: ${Math.max(
+                                            (booking.capacity || 0) - (booking.occupied || 0),
+                                            0,
+                                        )} de ${booking.capacity || 0}`}
+                                        reserved
+                                        onPress={(classData) => {
+                                            router.push({
+                                                pathname: '/class-details',
+                                                params: {
+                                                    ...classData,
+                                                    capacity: String(booking.capacity),
+                                                    occupied: String(booking.occupied),
+                                                    classId: booking.classId,
+                                                    serviceId: booking.serviceId,
+                                                    instructorId: booking.instructorId,
+                                                    bookingId: booking.bookingId,
+                                                },
+                                            });
+                                        }}
+                                    />
+                                ))}
+
+                            {!loadingBookings &&
+                                !bookingsError &&
+                                bookings.length > visibleBookingsCount && (
+                                    <View className='items-center mt-2 mb-4'>
+                                        <Pressable
+                                            onPress={() =>
+                                                setVisibleBookingsCount((prev) =>
+                                                    Math.min(prev + PAGE_SIZE, bookings.length),
+                                                )
+                                            }
+                                            className='px-4 py-2 rounded-full border border-orange-500'
+                                        >
+                                            <ThemedText className='text-sm font-semibold text-orange-500'>
+                                                Cargar más
+                                            </ThemedText>
+                                        </Pressable>
+                                    </View>
+                                )}
                         </View>
                     )}
                 </ScrollView>

--- a/app/class-details.tsx
+++ b/app/class-details.tsx
@@ -4,6 +4,8 @@ import { ThemedView } from '@/components/themed-view';
 import { useReservations } from '@/contexts/reservations';
 import { useToast } from '@/hooks/useToast';
 import vitalFitApi from '@/services/vitalfitSdk';
+import { isAPIError } from '@vitalfit/sdk';
+
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Image } from 'expo-image';
 import { useLocalSearchParams, useRouter } from 'expo-router';
@@ -22,7 +24,9 @@ const styles = StyleSheet.create({
 
 export default function ClassDetailsScreen() {
   const router = useRouter();
-  const { time, title, instructor, imageUrl, capacity, occupied, mode } = useLocalSearchParams();
+  const { time, title, instructor, imageUrl, capacity, occupied, mode, classId, serviceId, instructorId, bookingId } =
+    useLocalSearchParams();
+
   const { isReserved, reserve, cancel } = useReservations();
 
   const todayFormatted = useMemo(() => {
@@ -37,22 +41,100 @@ export default function ClassDetailsScreen() {
     }
   }, []);
 
+  const [serviceDescription, setServiceDescription] = useState<string | null>(null);
+  const [serviceImageUrl, setServiceImageUrl] = useState<string | null>(null);
+  const [instructorImageUrl, setInstructorImageUrl] = useState<string | null>(null);
+
+  type ApiServiceImage = { image_url?: string; is_primary?: boolean };
+  type ApiServiceDetail = { description?: string; images?: ApiServiceImage[] };
+  type ApiInstructorDetail = {
+    avatar_url?: string;
+    image_url?: string;
+    profile_image_url?: string;
+  };
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const token = await AsyncStorage.getItem('token');
+        if (!token) return;
+
+        if (serviceId) {
+          try {
+            const serviceResp = await vitalFitApi.client.get({
+              url: `/services/${String(serviceId)}`,
+              jwt: token,
+            });
+            const s =
+              (serviceResp as { data?: ApiServiceDetail }).data ??
+              (serviceResp as ApiServiceDetail | undefined);
+            if (s) {
+              if (typeof s.description === 'string') {
+                setServiceDescription(s.description);
+              }
+              const images: ApiServiceImage[] = Array.isArray(s.images) ? s.images : [];
+              if (images.length > 0) {
+                const primary = images.find((img) => img.is_primary) ?? images[0];
+                if (primary?.image_url) {
+                  setServiceImageUrl(primary.image_url);
+                }
+              }
+            }
+          } catch (error) {
+            console.error('Error cargando servicio para detalle de clase:', error);
+          }
+        }
+
+        if (instructorId) {
+          try {
+            const instResp = await vitalFitApi.client.get({
+              url: `/instructor/${String(instructorId)}`,
+              jwt: token,
+            });
+            const inst =
+              (instResp as { data?: ApiInstructorDetail }).data ??
+              (instResp as ApiInstructorDetail | undefined);
+            const avatar = inst?.avatar_url || inst?.image_url || inst?.profile_image_url;
+            if (typeof avatar === 'string' && avatar.startsWith('http')) {
+              setInstructorImageUrl(avatar);
+            }
+          } catch (error) {
+            console.error('Error cargando instructor para detalle de clase:', error);
+          }
+        }
+      } catch {
+        // ignorar
+      }
+    })();
+  }, [serviceId, instructorId]);
+
   const heroSource = useMemo(() => {
-    const t = String(title || '').toLowerCase();
-    const localByTitle: Record<string, number> = {
-      zumba: require('@/assets/images/zumba-w.jpg'),
-      spinning: require('@/assets/images/spinning-w.jpg'),
-      'yoga flow': require('@/assets/images/yoga-w.jpg'),
-      crossfit: require('@/assets/images/crossfit-w.jpg'),
-    };
-    const fromTitle = localByTitle[t];
+    // Priorizar imagen real del servicio, luego la que viene de Schedule
+    if (serviceImageUrl && /^https?:\/\//i.test(serviceImageUrl)) {
+      return { uri: serviceImageUrl };
+    }
+
+    if (typeof imageUrl === 'number') {
+      return imageUrl;
+    }
+
     const url = imageUrl as string | undefined;
-    if (url && /^https?:\/\//i.test(url)) return { uri: url };
-    if (fromTitle) return fromTitle;
-    return require('@/assets/images/yoga-w.jpg');
-  }, [imageUrl, title]);
+    if (url && /^https?:\/\//i.test(url)) {
+      return { uri: url };
+    }
+
+    // Solo usar imagen mock si NO hay serviceId asociado
+    if (!serviceId) {
+      return require('@/assets/images/yoga-w.jpg');
+    }
+
+    return null;
+  }, [imageUrl, serviceImageUrl, serviceId]);
 
   const description = useMemo(() => {
+    if (serviceDescription) return serviceDescription;
+    // Si hay servicio asociado pero aún no tenemos descripción, no mostrar texto mock
+    if (serviceId) return '';
     const t = String(title || '').toLowerCase();
     const map: Record<string, string> = {
       zumba: 'Clase de baile fitness con ritmos latinos para mejorar resistencia y coordinación. Ideal para todos los niveles y enfocada en divertirse mientras quemas calorías.',
@@ -67,18 +149,22 @@ export default function ClassDetailsScreen() {
       map[t] ||
       'Entrenamiento diseñado para mejorar tu condición física con foco en técnica y progreso seguro. Incluye trabajo de fuerza, movilidad y resistencia.'
     );
-  }, [title]);
+  }, [serviceDescription, serviceId, title]);
 
   const capNum = Number(capacity ?? 25);
   const occNumInitial = Number(occupied ?? 18);
-  const [forceFull, setForceFull] = useState(false);
+  const [forceFull] = useState(false);
+
   const [showCancelModal, setShowCancelModal] = useState(false);
   const isFullInitial = occNumInitial >= capNum;
   const effectiveFull = isFullInitial || forceFull;
   const occNum = effectiveFull ? capNum : occNumInitial;
 
   const id = useMemo(() => `${String(title || '')}|${String(time || '')}`, [title, time]);
-  const reserved = isReserved(id);
+  const reservedFromContext = isReserved(id);
+  const hasBookingId = Boolean(bookingId);
+  const reserved = reservedFromContext || hasBookingId;
+
   const { showToast } = useToast();
   const isCrossfitCompleted =
     String(title || '').toLowerCase() === 'crossfit' && effectiveFull;
@@ -612,20 +698,13 @@ export default function ClassDetailsScreen() {
           </ThemedText>
         </View>
 
-        <View className='flex-row items-center mb-3'>
-          <StarIcon size={16} color='#F59E0B' />
-          <ThemedText
-            lightColor='#4b5563'
-            darkColor='#e5e5e5'
-            className='ml-2 text-sm'
-            style={{ fontFamily: 'Montserrat_400Regular' }}>
-            4.9 (231 reviews)
-          </ThemedText>
-        </View>
-
         <View className='flex-row items-center mb-4'>
           <Image
-            source={{ uri: 'https://randomuser.me/api/portraits/men/32.jpg' }}
+            source={
+              instructorImageUrl && instructorImageUrl.startsWith('http')
+                ? { uri: instructorImageUrl }
+                : { uri: 'https://randomuser.me/api/portraits/men/32.jpg' }
+            }
             style={{ width: 28, height: 28, borderRadius: 9999 }}
             contentFit='cover'
           />
@@ -655,33 +734,6 @@ export default function ClassDetailsScreen() {
           </ThemedText>
         </View>
 
-        <View className='mb-4'>
-          <ThemedText
-            lightColor='#f97316'
-            darkColor='#f97316'
-            className='font-semibold'
-            style={{ fontFamily: 'Montserrat_600SemiBold' }}>
-            Nivel: intermedio
-          </ThemedText>
-        </View>
-
-        <View className='mb-4 flex-row items-baseline'>
-          <ThemedText
-            lightColor='#111827'
-            darkColor='#ffffff'
-            className='font-semibold text-sm'
-            style={{ fontFamily: 'Montserrat_600SemiBold' }}>
-            Ubicación / Sala:
-          </ThemedText>
-          <ThemedText
-            lightColor='#6b7280'
-            darkColor='#d4d4d4'
-            className='text-sm ml-1'
-            style={{ fontFamily: 'Montserrat_400Regular' }}>
-            Sala B - Planta 2
-          </ThemedText>
-        </View>
-
         {isCrossfitCompleted ? (
           <View className='mb-6 items-center'>
             <View className='flex-row items-center rounded-full px-4 py-2 bg-emerald-50'>
@@ -702,24 +754,49 @@ export default function ClassDetailsScreen() {
               style={{ backgroundColor: effectiveFull ? '#6b7280' : reserved ? '#ef4444' : '#f97316' }}
               onPress={async () => {
                 if (effectiveFull) return;
+
                 if (reserved) {
                   setShowCancelModal(true);
                   return;
                 }
-                const lowerTitle = String(title || '').toLowerCase();
-                const img =
-                  typeof heroSource === 'number'
-                    ? heroSource
-                    : (imageUrl as string | number | undefined);
-                if (lowerTitle === 'yoga flow') {
-                  showToast(
-                    'error',
-                    'Clase llena',
-                    'La clase se llenó mientras la reservabas.'
-                  );
-                  return;
-                }
-                if (lowerTitle === 'crossfit') {
+
+                try {
+                  const token = await AsyncStorage.getItem('token');
+                  if (!token) {
+                    showToast(
+                      'error',
+                      'Sesión no válida',
+                      'Inicia sesión nuevamente para reservar la clase.',
+                    );
+                    return;
+                  }
+
+                  if (!classId) {
+                    showToast(
+                      'error',
+                      'No se pudo reservar',
+                      'Falta el identificador de la clase.',
+                    );
+                    return;
+                  }
+
+                  // Obtener el user_id a partir del JWT para enviarlo en el payload
+                  const whoAmI = (await vitalFitApi.user.WhoAmI(token)) as unknown as {
+                    user?: { id?: string; user_id?: string };
+                  };
+                  const userId = whoAmI?.user?.id || whoAmI?.user?.user_id;
+
+                  await vitalFitApi.client.post({
+                    url: `/schedule/${String(classId)}/book`,
+                    jwt: token,
+                    data: userId ? { user_id: String(userId) } : undefined,
+                  });
+
+                  const img =
+                    typeof heroSource === 'number'
+                      ? heroSource
+                      : (imageUrl as string | number | undefined);
+
                   await reserve({
                     id,
                     title: String(title || ''),
@@ -727,27 +804,23 @@ export default function ClassDetailsScreen() {
                     instructor: String(instructor || ''),
                     imageUrl: img,
                   });
-                  setForceFull(true);
+
                   showToast(
                     'success',
                     'Clase reservada',
-                    'Su clase ha sido reservada correctamente'
+                    'Tu clase ha sido reservada correctamente.',
                   );
-                  return;
-                }
-                await reserve({
-                  id,
-                  title: String(title || ''),
-                  time: String(time || ''),
-                  instructor: String(instructor || ''),
-                  imageUrl: img,
-                });
-                if (lowerTitle === 'spinning') {
-                  showToast(
-                    'success',
-                    'Clase reservada',
-                    'Su clase ha sido reservada correctamente'
-                  );
+
+                  router.back();
+                } catch (error: unknown) {
+                  let message = 'Ocurrió un error al reservar la clase.';
+                  if (isAPIError(error)) {
+                    message = error.messages.join(', ');
+                  } else if (error instanceof Error) {
+                    message = error.message;
+                  }
+                  console.error('Error al reservar clase:', error);
+                  showToast('error', 'No se pudo reservar', message);
                 }
               }}
             />
@@ -790,8 +863,44 @@ export default function ClassDetailsScreen() {
               <TouchableOpacity
                 activeOpacity={0.8}
                 onPress={async () => {
-                  await cancel(id);
-                  setShowCancelModal(false);
+                  try {
+                    const token = await AsyncStorage.getItem('token');
+                    if (!token) {
+                      showToast(
+                        'error',
+                        'Sesión no válida',
+                        'Inicia sesión nuevamente para cancelar la reserva.',
+                      );
+                      return;
+                    }
+
+                    if (bookingId) {
+                      await vitalFitApi.client.patch({
+                        url: `/bookings/${String(bookingId)}/cancel`,
+                        jwt: token,
+                      });
+                    }
+
+                    await cancel(id);
+                    setShowCancelModal(false);
+
+                    showToast(
+                      'success',
+                      'Reserva cancelada',
+                      'Tu reserva ha sido cancelada correctamente.',
+                    );
+
+                    router.back();
+                  } catch (error: unknown) {
+                    let message = 'Ocurrió un error al cancelar la reserva.';
+                    if (isAPIError(error)) {
+                      message = error.messages.join(', ');
+                    } else if (error instanceof Error) {
+                      message = error.message;
+                    }
+                    console.error('Error al cancelar reserva:', error);
+                    showToast('error', 'No se pudo cancelar', message);
+                  }
                 }}
                 className='py-3 rounded-2xl items-center'
                 style={{ backgroundColor: '#f97316' }}>

--- a/components/ClassCard.tsx
+++ b/components/ClassCard.tsx
@@ -98,7 +98,7 @@ export default function ClassCard({
 						</View>
 					</View>
 					{reserved ? (
-						<View className='absolute top-3 left-3 bg-orange-500 rounded-full px-2 py-1'>
+						<View className='absolute top-3 right-3 bg-orange-500 rounded-full px-2 py-1'>
 							<ThemedText
 								lightColor='#ffffff'
 								darkColor='#ffffff'

--- a/contexts/UserContext.tsx
+++ b/contexts/UserContext.tsx
@@ -1,0 +1,99 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { isAPIError } from '@vitalfit/sdk';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+import vitalFitApi from '@/services/vitalfitSdk';
+
+export type UserData = {
+	userId: string;
+	firstName: string;
+	lastName: string;
+	email: string;
+	phone: string;
+	gender: string;
+	birthDate: string;
+	identityDocument: string;
+};
+
+type UserContextType = {
+	user: UserData | null;
+	loading: boolean;
+	error: string | null;
+	fetchUser: () => Promise<void>;
+	updateLocalUser: (partial: Partial<UserData>) => void;
+};
+
+const UserContext = createContext<UserContextType | undefined>(undefined);
+
+export function UserProvider({ children }: { children: React.ReactNode }) {
+	const [user, setUser] = useState<UserData | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	const fetchUser = useCallback(async () => {
+		try {
+			setLoading(true);
+			setError(null);
+
+			const token = await AsyncStorage.getItem('token');
+			if (!token) {
+				setUser(null);
+				setError('No se encontró token de autenticación');
+				return;
+			}
+
+			const userData = await vitalFitApi.user.WhoAmI(token);
+			const apiUser = userData?.user;
+
+			if (!apiUser) {
+				setUser(null);
+				setError('No se encontraron datos de usuario');
+				return;
+			}
+
+			const normalizedGender = apiUser.gender === 'male' ? 'M' : apiUser.gender === 'female' ? 'F' : '';
+
+			setUser({
+				userId: apiUser.user_id || '',
+				firstName: apiUser.first_name || '',
+				lastName: apiUser.last_name || '',
+				email: apiUser.email || '',
+				phone: apiUser.phone || '',
+				gender: normalizedGender,
+				birthDate: apiUser.birth_date || '',
+				identityDocument: apiUser.identity_document || '',
+			});
+		} catch (err: unknown) {
+			let message = 'Ocurrió un error inesperado al obtener los datos del usuario.';
+			if (isAPIError(err)) {
+				message = err.messages.join(', ');
+			} else if (err instanceof Error) {
+				message = err.message;
+			}
+			setError(message);
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	const updateLocalUser = useCallback((partial: Partial<UserData>) => {
+		setUser(prev => (prev ? { ...prev, ...partial } : prev));
+	}, []);
+
+	useEffect(() => {
+		fetchUser();
+	}, [fetchUser]);
+
+	const value = useMemo<UserContextType>(
+		() => ({ user, loading, error, fetchUser, updateLocalUser }),
+		[user, loading, error, fetchUser, updateLocalUser],
+	);
+
+	return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
+}
+
+export function useUser() {
+	const ctx = useContext(UserContext);
+	if (!ctx) throw new Error('useUser must be used within a UserProvider');
+	return ctx;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -287,6 +287,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -4511,6 +4512,7 @@
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
       "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5286,6 +5288,7 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.19.tgz",
       "integrity": "sha512-fM7q8di4Q8sp2WUhiUWOe7bEDRyRhbzsKQOd5N2k+lHeCx3UncsRYuw4Q/KN0EovM3wWKqMMmhy/YWuEO04kgw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.13.0",
         "escape-string-regexp": "^4.0.0",
@@ -5620,7 +5623,6 @@
       "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -5730,6 +5732,7 @@
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -5842,6 +5845,7 @@
       "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.45.0",
         "@typescript-eslint/types": "8.45.0",
@@ -6367,7 +6371,6 @@
       "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -6378,24 +6381,21 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
       "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
       "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
       "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
@@ -6403,7 +6403,6 @@
       "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -6415,8 +6414,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
       "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
@@ -6424,7 +6422,6 @@
       "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -6438,7 +6435,6 @@
       "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -6449,7 +6445,6 @@
       "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
@@ -6459,8 +6454,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
       "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
@@ -6468,7 +6462,6 @@
       "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -6486,7 +6479,6 @@
       "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -6501,7 +6493,6 @@
       "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -6515,7 +6506,6 @@
       "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -6531,7 +6521,6 @@
       "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
@@ -6551,16 +6540,14 @@
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
       "devOptional": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "devOptional": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@zxcvbn-ts/core": {
       "version": "3.0.4",
@@ -6636,6 +6623,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6660,7 +6648,6 @@
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -6736,7 +6723,6 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -6755,7 +6741,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6772,8 +6757,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/alien-signals": {
       "version": "2.0.6",
@@ -7096,6 +7080,7 @@
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
       "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/transform": "^29.7.0",
         "@types/babel__core": "^7.1.14",
@@ -7508,6 +7493,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -7777,7 +7763,6 @@
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -9127,8 +9112,7 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -9254,6 +9238,7 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9377,6 +9362,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -9592,6 +9578,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -10122,7 +10109,6 @@
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -10253,6 +10239,7 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.25.tgz",
       "integrity": "sha512-+iSeBJfHRHzNPnHMZceEXhSGw4t5bNqFyd/5xMUoGfM+39rO7F72wxiLRpBKj0M6+0GQtMaEs+eTbcCrO7XyJQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.16",
@@ -10320,7 +10307,6 @@
       "resolved": "https://registry.npmjs.org/expo-auth-session/-/expo-auth-session-7.0.9.tgz",
       "integrity": "sha512-mPSwaRWOJYas160lXi5P/7BkLy0xbh+er+IMmAYHqf2+iz2WWs9W/4lMAklQVJG2mCyOZi24XrkffvB2izCa1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expo-application": "~7.0.7",
         "expo-constants": "~18.0.10",
@@ -10339,7 +10325,6 @@
       "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-7.0.7.tgz",
       "integrity": "sha512-Jt1/qqnoDUbZ+bK91+dHaZ1vrPDtRBOltRa681EeedkisqguuEeUx4UHqwVyDK2oHWsK6lO3ojetoA4h8OmNcg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "expo": "*"
       }
@@ -10349,7 +10334,6 @@
       "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-15.0.7.tgz",
       "integrity": "sha512-FUo41TwwGT2e5rA45PsjezI868Ch3M6wbCZsmqTWdF/hr+HyPcrp1L//dsh/hsrsyrQdpY/U96Lu71/wXePJeg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0"
       },
@@ -10389,6 +10373,7 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.10.tgz",
       "integrity": "sha512-Rhtv+X974k0Cahmvx6p7ER5+pNhBC0XbP1lRviL2J1Xl4sT2FBaIuIxF/0I0CbhOsySf0ksqc5caFweAy9Ewiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@expo/config": "~12.0.10",
         "@expo/env": "~2.0.7"
@@ -10413,6 +10398,7 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.9.tgz",
       "integrity": "sha512-xCoQbR/36qqB6tew/LQ6GWICpaBmHLhg/Loix5Rku/0ZtNaXMJv08M9o1AcrdiGTn/Xf/BnLu6DgS45cWQEHZg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -10474,6 +10460,7 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.9.tgz",
       "integrity": "sha512-a0UHhlVyfwIbn8b1PSFPoFiIDJeps2iEq109hVH3CHd0CMKuRxFfNio9Axe2BjXhiJCYWR4OV1iIyzY/GjiVkQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "expo-constants": "~18.0.10",
         "invariant": "^2.2.4"
@@ -10881,6 +10868,7 @@
       "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-15.0.7.tgz",
       "integrity": "sha512-9q7+G1Zxr5P6J5NRIlm86KulvmYwc6UnQlYPjQLDu1drDnerz6AT6l884dPu29HgtDTn4rR0heYeeGFhMKM7/Q==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "expo": "*"
       }
@@ -10957,6 +10945,7 @@
       "resolved": "https://registry.npmjs.org/expo-web-browser/-/expo-web-browser-15.0.9.tgz",
       "integrity": "sha512-Dj8kNFO+oXsxqCDNlUT/GhOrJnm10kAElH++3RplLydogFm5jTzXYWDEeNIDmV+F+BzGYs+sIhxiBf7RyaxXZg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
@@ -11243,8 +11232,7 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -12157,6 +12145,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -13034,6 +13023,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -14176,6 +14166,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -14876,7 +14867,6 @@
       "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       }
@@ -16695,6 +16685,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -16851,6 +16842,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -17361,7 +17353,6 @@
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -17423,6 +17414,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -17453,6 +17445,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.63.0.tgz",
       "integrity": "sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -17890,6 +17883,7 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
       "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -17965,6 +17959,7 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.2.tgz",
       "integrity": "sha512-qzmQiFrvjm62pRBcj97QI9Xckc3EjgHQoY1F2yjktd0kpjhoyePeuTEXjYRCAVIy7IV/1cfeSup34+zFThFoHQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "7.7.2"
@@ -17993,6 +17988,7 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.1.tgz",
       "integrity": "sha512-/wJE58HLEAkATzhhX1xSr+fostLsK8Q97EfpfMDKo8jlOc1QKESSX/FQrhk7HhQH/2uSaox4Y86sNaI02kteiA==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -18003,6 +17999,7 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -18018,6 +18015,7 @@
       "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz",
       "integrity": "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css-select": "^5.1.0",
         "css-tree": "^1.1.3",
@@ -18051,6 +18049,7 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.1.tgz",
       "integrity": "sha512-BeNsgwwe4AXUFPAoFU+DKjJ+CVQa3h54zYX77p7GVZrXiiNo3vl03WYDYVEy5R2J2HOPInXtQZB5gmj3vuzrKg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -18215,6 +18214,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18272,6 +18272,7 @@
       "integrity": "sha512-hLug9KEXLc8vnU9lDNe2b2rKKDaqrp5gNiES4uyu2Up3FZfZJZmdwLFXlWzdA9gTB/6/cWduSB2K1Lfag2pSvw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "acorn-loose": "^8.3.0",
         "neo-async": "^2.6.1",
@@ -18314,6 +18315,7 @@
       "integrity": "sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-is": "^19.1.0",
         "scheduler": "^0.26.0"
@@ -18855,7 +18857,6 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -18894,7 +18895,6 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -18907,8 +18907,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -18994,7 +18993,6 @@
       "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "devOptional": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -19913,6 +19911,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -20069,7 +20068,6 @@
       "integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
@@ -20105,7 +20103,6 @@
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -20121,7 +20118,6 @@
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -20270,6 +20266,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -20619,6 +20616,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20939,6 +20937,7 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -21368,7 +21367,6 @@
       "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -21398,7 +21396,6 @@
       "integrity": "sha512-hUtqAR3ZLVEYDEABdBioQCIqSoguHbFn1K7WlPPWSuXmx0031BD73PSE35jKyftdSh4YLDoQNgK4pqBt5Q82MA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -21458,7 +21455,6 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "devOptional": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -21473,7 +21469,6 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "devOptional": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -21791,6 +21786,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -21986,6 +21982,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
Description
Sincronización completa de los datos del cliente al editar el perfil, usando la información real del usuario autenticado.
Integración de los endpoints de horarios y reservas para cargar clases y reservas desde la API (sin datos mock).
Unificación de la UI entre listado de clases y listado de reservas, reutilizando la misma tarjeta con indicación de “Reservado”.
Implementación del flujo de reserva (POST /schedule/{classId}/book) y cancelación (PATCH /bookings/{bookingId}/cancel) con user_id obtenido desde el JWT.
Actualización dinámica de capacidad (max_capacity y occupied) tras reservar/cancelar, bloqueando la reserva cuando la clase está llena.
Refresco automático de horarios y reservas al volver a la pestaña correspondiente.

Related Issue
Pendiente de asociar al issue correspondiente de sincronización de perfil y de integración de horarios/reservas (ej: #NNN).
Motivation and Context
Evitar inconsistencias entre la información mostrada en el horario, las reservas y el perfil del usuario.
Reemplazar datos mock por datos reales de la API, respetando imágenes de servicios e instructores.
Permitir al cliente reservar y cancelar clases de forma confiable, con el backend recibiendo el user_id correcto.
Asegurar que la capacidad de las clases se refleje en la UI y que el usuario no pueda reservar cupos inexistentes.

How Has This Been Tested?
Login como cliente y navegación a la pestaña de horarios.
Reserva de una clase desde la pantalla de detalle:
Verificación de actualización de max_capacity/occupied en la tarjeta de la clase.
Revisión de la pestaña de reservas:
Confirmación de que la clase recién reservada aparece con el estilo unificado y la etiqueta de “Reservado”.
Cancelación de una reserva desde el detalle:
Verificación de aparición de toast de confirmación de cancelación.
Verificación de que la reserva desaparece de la lista y que la capacidad se actualiza en el horario.
Verificación de refresco automático de listas al cambiar de pestaña o volver atrás.

Screenshots (if appropriate):

https://github.com/user-attachments/assets/582c8112-c176-4c4b-b8c2-40c858a8531c

