### PR TITLE
cambio contraseña implementado

### DIFF
--- a/app/(tabs)/profile/change-password.tsx
+++ b/app/(tabs)/profile/change-password.tsx
@@ -1,0 +1,218 @@
+import { PrimaryButton } from '@/components/PrimaryButton';
+import { StyledTextInput } from '@/components/StyledTextInput';
+import { ToastNotification } from '@/components/ToastNotification';
+import { ThemedView } from '@/components/themed-view';
+import { useToast } from '@/hooks/useToast';
+import vitalFitApi from '@/services/vitalfitSdk';
+import { zodResolver } from '@hookform/resolvers/zod';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { isAPIError } from '@vitalfit/sdk';
+import { useRouter } from 'expo-router';
+import React, { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { KeyboardAvoidingView, Platform, ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { ChevronLeftIcon, ShieldCheckIcon } from 'react-native-heroicons/solid';
+import { z } from 'zod';
+
+const ChangePasswordSchema = z
+  .object({
+    currentPassword: z.string().min(1, 'Ingresa tu contraseña actual.'),
+    newPassword: z
+      .string()
+      .min(8, 'La contraseña debe tener al menos 8 caracteres.')
+      .regex(/[A-Z]/, 'Debe contener al menos una mayúscula.')
+      .regex(/[a-z]/, 'Debe contener al menos una minúscula.')
+      .regex(/[0-9]/, 'Debe contener al menos un número.')
+      .regex(/[^a-zA-Z0-9]/, 'Debe contener al menos un caracter especial.'),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: 'Las contraseñas no coinciden.',
+    path: ['confirmPassword'],
+  });
+
+type FormData = z.infer<typeof ChangePasswordSchema>;
+
+export default function ChangePasswordScreen() {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { toastState, showToast, hideToast } = useToast();
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({
+    resolver: zodResolver(ChangePasswordSchema),
+    defaultValues: {
+      currentPassword: '',
+      newPassword: '',
+      confirmPassword: '',
+    },
+    mode: 'onChange',
+  });
+
+  const onSubmit = async (data: FormData) => {
+    setIsLoading(true);
+    setErrorMessage(null);
+    try {
+      const token = await AsyncStorage.getItem('token');
+      if (!token) {
+        setErrorMessage('No se encontró sesión activa');
+        return;
+      }
+
+      await vitalFitApi.user.UpgradePassword(
+        token,
+        data.currentPassword,
+        data.newPassword,
+        data.confirmPassword
+      );
+
+      showToast('success', 'Contraseña actualizada', 'La contraseña se guardó correctamente');
+      
+      setTimeout(() => {
+        router.back();
+      }, 2000);
+    } catch (error: unknown) {
+      console.log('Error al cambiar password:', error);
+
+      let message = 'Ocurrió un error al cambiar la contraseña.';
+
+      if (isAPIError(error)) {
+        if (error.status === 401) {
+          message = 'La contraseña actual es incorrecta.';
+        } else if (error.messages && error.messages.length > 0) {
+          message = error.messages.join(', ');
+        } else if (error.message && error.message !== 'Ocurrió un error inesperado') {
+          message = error.message;
+        } else {
+          message = 'Verifique su contraseña actual e intente nuevamente.';
+        }
+      } else if (error instanceof Error) {
+        message = error.message;
+      }
+
+      setErrorMessage(message);
+      showToast('error', 'Error', message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <ThemedView className='flex-1 bg-white pt-10'>
+      <ToastNotification
+        visible={toastState.visible}
+        type={toastState.type}
+        title={toastState.title}
+        message={toastState.message}
+        onClose={hideToast}
+      />
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 20}>
+        <ScrollView
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 96 }}>
+          <View
+            className='w-full bg-[#F3F4F6] rounded-2xl py-2 mb-3 items-center justify-center'
+            style={{ position: 'relative' }}>
+            <TouchableOpacity
+              activeOpacity={0.7}
+              onPress={() => router.back()}
+              style={{ position: 'absolute', left: 12, top: 8, bottom: 8, justifyContent: 'center' }}>
+              <ChevronLeftIcon width={20} height={20} color='#f97316' />
+            </TouchableOpacity>
+
+            <Text style={{ color: '#111827', fontSize: 16, fontWeight: '600' }}>
+              Cambiar contraseña
+            </Text>
+          </View>
+
+          <View className='mb-4 flex-row items-center'>
+            <View className='w-9 h-9 rounded-full bg-[#F3F4F6] items-center justify-center mr-3'>
+              <ShieldCheckIcon width={20} height={20} color='#111827' />
+            </View>
+            <View className='flex-1'>
+              <Text className='text-[15px] font-semibold text-[#111827]'>Seguridad de la cuenta</Text>
+              <Text className='text-[12px] text-[#6b7280]'>Actualiza tu contraseña de acceso</Text>
+            </View>
+          </View>
+
+          {errorMessage && (
+            <View
+              style={{
+                backgroundColor: '#FEF2F2',
+                borderRadius: 10,
+                paddingVertical: 8,
+                paddingHorizontal: 10,
+                marginBottom: 12,
+              }}>
+              <Text style={{ color: '#B91C1C', fontSize: 12 }}>{errorMessage}</Text>
+            </View>
+          )}
+
+          <View>
+            <Controller
+              control={control}
+              name='currentPassword'
+              render={({ field: { onChange, onBlur, value } }) => (
+                <StyledTextInput
+                  label='Contraseña actual'
+                  isPasswordInput
+                  onBlur={onBlur}
+                  onChangeText={onChange}
+                  value={value}
+                  placeholder='Ingresa tu contraseña actual'
+                  error={errors.currentPassword?.message}
+                />
+              )}
+            />
+
+            <Controller
+              control={control}
+              name='newPassword'
+              render={({ field: { onChange, onBlur, value } }) => (
+                <StyledTextInput
+                  label='Nueva contraseña'
+                  isPasswordInput
+                  onBlur={onBlur}
+                  onChangeText={onChange}
+                  value={value}
+                  placeholder='Ingresa tu nueva contraseña'
+                  error={errors.newPassword?.message}
+                />
+              )}
+            />
+
+            <Controller
+              control={control}
+              name='confirmPassword'
+              render={({ field: { onChange, onBlur, value } }) => (
+                <StyledTextInput
+                  label='Confirmar contraseña'
+                  isPasswordInput
+                  onBlur={onBlur}
+                  onChangeText={onChange}
+                  value={value}
+                  placeholder='Repite tu nueva contraseña'
+                  error={errors.confirmPassword?.message}
+                />
+              )}
+            />
+
+            <PrimaryButton
+              title={isLoading ? 'Guardando...' : 'Guardar cambios'}
+              onPress={handleSubmit(onSubmit)}
+              disabled={isLoading}
+              style={{ marginTop: 12 }}
+            />
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </ThemedView>
+  );
+}

--- a/app/(tabs)/profile/profile-settings.tsx
+++ b/app/(tabs)/profile/profile-settings.tsx
@@ -12,7 +12,6 @@ export default function SettingsScreen() {
 			<ScrollView
 				showsVerticalScrollIndicator={false}
 				contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 96 }}>
-				{/* Franja superior */}
 				<View
 					className='w-full bg-[#F3F4F6] rounded-2xl py-2 mb-3 items-center justify-center'
 					style={{ position: 'relative' }}>
@@ -26,17 +25,15 @@ export default function SettingsScreen() {
 					<Text style={{ color: '#111827', fontSize: 16, fontWeight: '600' }}>Seguridad</Text>
 				</View>
 
-				{/* Opciones de seguridad */}
 				<View className='mb-2'>
 					<Text className='text-[14px] font-semibold text-[#111827] mb-2'>Opciones</Text>
 				</View>
 
-				{/* Cambiar contraseña */}
 				<TouchableOpacity
 					activeOpacity={0.8}
 					className='w-full flex-row items-center justify-between rounded-2xl bg-white border border-[#e5e7eb] px-4 py-3 mb-3'
 					onPress={() => {
-						router.push('/instructor-change-password');
+						router.push('./change-password');
 					}}>
 					<View className='flex-row items-center'>
 						<View className='w-8 h-8 rounded-full bg-[#F3F4F6] items-center justify-center mr-3'>

--- a/app/instructor-change-password.tsx
+++ b/app/instructor-change-password.tsx
@@ -1,12 +1,15 @@
 import { PrimaryButton } from '@/components/PrimaryButton';
 import { StyledTextInput } from '@/components/StyledTextInput';
 import { ThemedView } from '@/components/themed-view';
-import vitalFitApi from '@/services/vitalfitSdk';
-import { isAPIError } from '@vitalfit/sdk';
 import { useRouter } from 'expo-router';
 import React, { useState } from 'react';
-import { KeyboardAvoidingView, Platform, ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { Alert, KeyboardAvoidingView, Platform, ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import { ChevronLeftIcon, ShieldCheckIcon } from 'react-native-heroicons/solid';
+
+import vitalFitApi from '@/services/vitalfitSdk';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { isAPIError } from '@vitalfit/sdk';
+
 
 export default function InstructorChangePasswordScreen() {
   const router = useRouter();
@@ -26,8 +29,6 @@ export default function InstructorChangePasswordScreen() {
     setIsLoading(true);
     setErrorMessage(null);
     try {
-      // Opcional: llamar a un endpoint de validación si existe.
-      // Por ahora asumimos que el backend validará junto con el cambio final.
       setStep(2);
     } finally {
       setIsLoading(false);
@@ -47,20 +48,30 @@ export default function InstructorChangePasswordScreen() {
     setIsLoading(true);
     setErrorMessage(null);
     try {
-      await vitalFitApi.client.post({
-        url: '/auth/password/change',
-        data: {
-          current_password: currentPassword,
-          password: newPassword,
-          confirm_password: confirmPassword,
-        },
-      });
+      const token = await AsyncStorage.getItem('token');
+      if (!token) throw new Error('No se encontró sesión activa');
 
-      router.back();
+      await vitalFitApi.user.UpgradePassword(
+        token,
+        currentPassword,
+        newPassword,
+        confirmPassword
+      );
+
+      Alert.alert('Éxito', 'Contraseña actualizada correctamente', [
+        { text: 'OK', onPress: () => router.back() },
+      ]);
     } catch (error: unknown) {
       let message = 'Ocurrió un error al cambiar la contraseña.';
+      
       if (isAPIError(error)) {
-        message = error.messages.join(', ');
+        if (error.status === 401) {
+          message = 'La contraseña actual es incorrecta.';
+        } else if (error.messages && error.messages.length > 0) {
+          message = error.messages.join(', ');
+        } else if (error.message && error.message !== 'Ocurrió un error inesperado') {
+          message = error.message;
+        }
       } else if (error instanceof Error) {
         message = error.message;
       }
@@ -79,7 +90,6 @@ export default function InstructorChangePasswordScreen() {
         <ScrollView
           showsVerticalScrollIndicator={false}
           contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 96 }}>
-          {/* Franja superior */}
           <View
             className='w-full bg-[#F3F4F6] rounded-2xl py-2 mb-3 items-center justify-center'
             style={{ position: 'relative' }}>
@@ -98,7 +108,6 @@ export default function InstructorChangePasswordScreen() {
             </Text>
           </View>
 
-          {/* Header de seguridad */}
           <View className='mb-4 flex-row items-center'>
             <View className='w-9 h-9 rounded-full bg-[#F3F4F6] items-center justify-center mr-3'>
               <ShieldCheckIcon width={20} height={20} color='#111827' />

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
-        "@vitalfit/sdk": "^0.0.73",
+        "@vitalfit/sdk": "^0.1.7",
         "axios": "^1.12.2",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -6361,9 +6361,9 @@
       }
     },
     "node_modules/@vitalfit/sdk": {
-      "version": "0.0.73",
-      "resolved": "https://registry.npmjs.org/@vitalfit/sdk/-/sdk-0.0.73.tgz",
-      "integrity": "sha512-SE8SctQQiIeT6FuLAozsPq018WmLFIJzyuh9M2pM7iWpFOmpGatSBwDZDQl+XAP/OyLEwEhD03yx2MH13RhoEA==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@vitalfit/sdk/-/sdk-0.1.7.tgz",
+      "integrity": "sha512-mkqUYwEAMoVCKYhq5pPNo2DY9ne9u3ya6BDEchvkr/Ko2a7GP/Kxe//8xEL5x3WRsQOTfsaKUV+xlH2TZSVb1w==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.12.2"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
-    "@vitalfit/sdk": "^0.0.73",
+    "@vitalfit/sdk": "^0.1.7",
     "axios": "^1.12.2",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",


### PR DESCRIPTION
Description
Se creó un nuevo archivo app/(tabs)/profile/change-password.tsx para el cambio de contraseña de clientes, eliminando la lógica de pasos (steps) para mostrar todos los campos en una sola vista. Se actualizó la ruta de navegación en profile-settings.tsx para apuntar a esta nueva pantalla y se limpió la lógica de petición incorrecta en instructor-change-password.tsx. Además, se implementó la llamada correcta al SDK (UpgradePassword) enviando el token de sesión y manejando errores de validación (401).
Se implementó el sistema de notificaciones ToastNotification junto con el hook useToast en la pantalla de "Cambiar contraseña" (ChangePasswordScreen). Ahora, al actualizar la contraseña exitosamente o al recibir un error de la API, el usuario recibe feedback visual inmediato mediante un toast (verde para éxito, rojo para error).

Related Issue
Corriges el error de navegación en el perfil de cliente donde se redirigía a la pantalla de instructor. También soluciona el fallo de la petición API (Error 401) al asegurar el envío del token Bearer correcto.

Motivation and Context
La implementación anterior reutilizaba una pantalla de instructor con una petición fallida (sin token) y un flujo de pasos innecesario. Estos cambios son requeridos para permitir que el cliente cambie su contraseña exitosamente usando el endpoint correcto del SDK, mejorando la experiencia de usuario al unificar el formulario y proporcionando feedback claro sobre errores (como contraseña actual incorrecta). Anteriormente, la pantalla solo mostraba mensajes de error en texto plano o navegaba hacia atrás sin una confirmación visual clara de éxito. Este cambio mejora la experiencia de usuario (UX) al proporcionar confirmaciones explícitas de las acciones, asegurando que el usuario sepa si su contraseña fue actualizada correctamente o por qué falló el intento.

How Has This Been Tested?
Se realizaron pruebas manuales en el entorno de desarrollo:

Navegación desde Perfil -> Configuración -> Cambiar Contraseña.

Validación de formulario (campos vacíos, coincidencia de contraseñas).

Intento de cambio con contraseña actual errónea (verificación del mensaje de error 401).

Verificación de redirección exitosa tras un cambio de contraseña válido.
Se verificaron los siguientes flujos:

Éxito: Al cambiar la contraseña correctamente, aparece un toast de éxito ("Contraseña actualizada") y se espera 2 segundos antes de navegar a la pantalla anterior.

Error de API: Al simular un error (ej. contraseña actual incorrecta), aparece un toast de error con el mensaje específico devuelto por el servidor.

Validación: Se comprobó que el toast no interfiere con las validaciones locales de Zod (ej. contraseñas que no coinciden).

Screenshots (if appropriate):
![WhatsApp Image 2025-12-29 at 9 20 24 AM](https://github.com/user-attachments/assets/0ef202ea-b519-4613-b6b5-e101f632df24)
