### PR TITLE
 feat: mejorar pantalla de horarios con i18n y visualización de ocupación

### DIFF
--- a/app/(tabs)/schedule.tsx
+++ b/app/(tabs)/schedule.tsx
@@ -303,14 +303,14 @@ export default function HorariosScreen() {
                 setVisibleClassesCount(PAGE_SIZE);
             } catch (error) {
                 console.error('Error cargando clases en Schedule:', error);
-                setErrorMessage('No se pudieron cargar las clases. Intenta nuevamente.');
+                setErrorMessage(t('schedule.errorLoadingClasses'));
             } finally {
                 setLoadingClasses(false);
             }
         };
 
         void loadClasses();
-    }, [selectedBranchId, refreshKey]);
+    }, [selectedBranchId, refreshKey, t]);
 
     useEffect(() => {
         const loadBookings = async () => {
@@ -542,7 +542,7 @@ export default function HorariosScreen() {
                 setVisibleBookingsCount(PAGE_SIZE);
             } catch (error) {
                 console.error('Error cargando reservas del cliente:', error);
-                setBookingsError('No se pudieron cargar tus reservas. Intenta nuevamente.');
+                setBookingsError(t('schedule.errorLoadingBookings'));
             } finally {
                 setLoadingBookings(false);
             }
@@ -722,7 +722,8 @@ export default function HorariosScreen() {
                                     branch={classItem.branch}
                                     imageUrl={classItem.imageUrl}
                                     variant='overlay'
-                                    category={`${classItem.capacity || 0} Cupos`}
+                                    category=""
+                                    date={classItem.rawDate}
                                     reserved={isReserved(
                                         `${classItem.classId}|${classItem.serviceId}`,
                                     )}
@@ -795,10 +796,8 @@ export default function HorariosScreen() {
                                         branch={booking.branch}
                                         imageUrl={booking.imageUrl}
                                         variant='overlay'
-                                        category={`${t('common.available')}: ${Math.max(
-                                            (booking.capacity || 0) - (booking.occupied || 0),
-                                            0,
-                                        )} ${t('common.of')} ${booking.capacity || 0}`}
+                                        category=""
+                                        date={booking.rawDate}
                                         reserved
                                         onPress={(classData) => {
                                             router.push({

--- a/components/ClassCard.tsx
+++ b/components/ClassCard.tsx
@@ -1,5 +1,6 @@
 import { ThemedText } from '@/components/themed-text';
 import { Image } from 'expo-image';
+import i18n from 'i18next';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { TouchableOpacity, View } from 'react-native';
@@ -22,6 +23,7 @@ type ClassCardProps = {
 	variant?: 'default' | 'overlay';
 	category?: string;
 	reserved?: boolean;
+	date?: string;
 };
 
 export default function ClassCard({
@@ -34,10 +36,25 @@ export default function ClassCard({
 	variant = 'default',
 	category,
 	reserved,
+	date,
 }: ClassCardProps) {
 	const { t } = useTranslation();
 	const classData: ClassData = { time, title, instructor, branch, imageUrl };
 	const [imageError, setImageError] = React.useState(false);
+
+	const formatDate = (dateString?: string) => {
+		if (!dateString) return t('common.today');
+		const date = new Date(dateString + 'T00:00:00'); // Add time to ensure correct parsing
+		const today = new Date();
+		const isToday = date.toDateString() === today.toDateString();
+		if (isToday) return t('common.today');
+		
+		return date.toLocaleDateString(i18n.language, { 
+			weekday: 'long', 
+			day: 'numeric', 
+			month: 'short' 
+		});
+	};
 
 	if (variant === 'overlay') {
 		return (
@@ -79,7 +96,7 @@ export default function ClassCard({
 								darkColor='#E0E0E0'
 								style={{ fontFamily: 'Montserrat_500Medium', fontSize: 14, marginTop: 2 }}
 							>
-								{t('common.today')}, {time}
+								{formatDate(date)}, {time}
 							</ThemedText>
 							<ThemedText
 								className='font-body'

--- a/components/auth/dashboard/weekcalendar.tsx
+++ b/components/auth/dashboard/weekcalendar.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Dimensions, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { DateData } from 'react-native-calendars';
 
@@ -25,6 +26,7 @@ export const WeekCalendar: React.FC<WeekCalendarProps> = ({
 	markedDates = EMPTY_MARKED_DATES,
 	initialDate,
 }) => {
+	const { t } = useTranslation();
 	// Helper to format date as YYYY-MM-DD in local timezone
 	const formatLocalDate = (date: Date): string => {
 		const year = date.getFullYear();
@@ -42,7 +44,7 @@ export const WeekCalendar: React.FC<WeekCalendarProps> = ({
 		const generateWeekDays = () => {
 			const today = new Date();
 			const days: DayData[] = [];
-			const dayLabels = ['LUN', 'MAR', 'MIE', 'JUE', 'VIE', 'SAB', 'DOM'];
+			const dayLabels = t('common.weekdaysShort', { returnObjects: true }) as string[];
 
 			// Show today + next 6 days (7 days total, looking forward)
 			for (let i = 0; i < 7; i++) {
@@ -67,7 +69,7 @@ export const WeekCalendar: React.FC<WeekCalendarProps> = ({
 		};
 
 		generateWeekDays();
-	}, [markedDates]);
+	}, [markedDates, t]);
 
 	const handleDayPress = (day: DayData) => {
 		setSelectedDateString(day.dateString);

--- a/services/i18n/locales/de.json
+++ b/services/i18n/locales/de.json
@@ -99,7 +99,8 @@
 			"availability": "Verfügbarkeit",
 			"unknown": "Unbekannt",
 			"notes": "Notizen",
-			"noClientsFound": "Keine Kunden gefunden"
+			"noClientsFound": "Keine Kunden gefunden",
+			"weekdaysShort": ["MO", "DI", "MI", "DO", "FR", "SA", "SO"]
 		},
 		"enrollClient": {
 			"title": "Kunden anmelden",
@@ -418,6 +419,9 @@
 			"myBookings": "Meine Buchungen",
 			"noBookings": "Du hast noch keine Buchungen.",
 			"noClassesBranch": "Keine Kurse für diesen Standort geplant.",
+			"noClassesForDate": "Keine Kurse für das ausgewählte Datum verfügbar",
+			"errorLoadingClasses": "Kurse konnten nicht geladen werden. Bitte versuchen Sie es erneut.",
+			"errorLoadingBookings": "Buchungen konnten nicht geladen werden. Bitte versuchen Sie es erneut.",
 			"tabs": {
 				"classes": "Kurse",
 				"reservations": "Buchungen",

--- a/services/i18n/locales/en.json
+++ b/services/i18n/locales/en.json
@@ -103,7 +103,8 @@
       "close": "Close",
       "reviews": "reviews",
       "unnamedUser": "Unnamed User",
-      "noProgram": "No program"
+      "noProgram": "No program",
+      "weekdaysShort": ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"]
     },
     "login": {
       "title": "Sign In",
@@ -409,6 +410,8 @@
       "myBookings": "My Bookings",
       "noBookings": "You have no bookings yet.",
       "noClassesBranch": "No classes scheduled for this branch.",
+      "errorLoadingClasses": "Could not load classes. Please try again.",
+      "errorLoadingBookings": "Could not load your bookings. Please try again.",
       "noClassesForDate": "No classes available for the selected date",
       "tabs": {
         "classes": "Classes",

--- a/services/i18n/locales/es.json
+++ b/services/i18n/locales/es.json
@@ -103,7 +103,8 @@
 			"availability": "Disponibilidad",
 			"unknown": "Desconocido",
 			"notes": "Notas",
-			"noClientsFound": "No se encontraron clientes"
+			"noClientsFound": "No se encontraron clientes",
+			"weekdaysShort": ["LUN", "MAR", "MIÉ", "JUE", "VIE", "SÁB", "DOM"]
 		},
 		"enrollClient": {
 			"title": "Inscribir Cliente",
@@ -422,7 +423,10 @@
 			"spotsOccupied": "cupos ocupados",
 			"myBookings": "Mis reservas",
 			"noBookings": "Aún no tienes reservas.",
-			"noClassesBranch": "No hay clases programadas para esta sede.",
+			"noClassesBranch": "Ninguna lección programada para esta sede.",
+			"noClassesForDate": "No hay clases disponibles para la fecha seleccionada",
+			"errorLoadingClasses": "No se pudieron cargar las clases. Intenta nuevamente.",
+			"errorLoadingBookings": "No se pudieron cargar tus reservas. Intenta nuevamente.",
 			"tabs": {
 				"classes": "Clases",
 				"reservations": "Reservas",

--- a/services/i18n/locales/fr.json
+++ b/services/i18n/locales/fr.json
@@ -99,7 +99,8 @@
 			"availability": "Disponibilité",
 			"unknown": "Inconnu",
 			"notes": "Notes",
-			"noClientsFound": "Aucun client trouvé"
+			"noClientsFound": "Aucun client trouvé",
+			"weekdaysShort": ["LUN", "MAR", "MER", "JEU", "VEN", "SAM", "DIM"]
 		},
 		"enrollClient": {
 			"title": "Inscrire Client",
@@ -418,6 +419,9 @@
 			"myBookings": "Mes Réservations",
 			"noBookings": "Vous n'avez pas encore de réservations.",
 			"noClassesBranch": "Aucun cours prévu pour cette succursale.",
+			"noClassesForDate": "Aucun cours disponible pour la date sélectionnée",
+			"errorLoadingClasses": "Impossible de charger les cours. Veuillez réessayer.",
+			"errorLoadingBookings": "Impossible de charger vos réservations. Veuillez réessayer.",
 			"tabs": {
 				"classes": "Cours",
 				"reservations": "Réservations",

--- a/services/i18n/locales/it.json
+++ b/services/i18n/locales/it.json
@@ -98,7 +98,8 @@
 			"viewMore": "Vedi altro",
 			"availability": "Disponibilità",
 			"unknown": "Sconosciuto",
-			"notes": "Note"
+			"notes": "Note",
+			"weekdaysShort": ["LUN", "MAR", "MER", "GIO", "VEN", "SAB", "DOM"]
 		},
 		"login": {
 			"title": "Accedi",
@@ -416,6 +417,9 @@
 			"myBookings": "Mie Prenotazioni",
 			"noBookings": "Non hai ancora prenotazioni.",
 			"noClassesBranch": "Nessuna lezione programmata per questa sede.",
+			"noClassesForDate": "Nessuna lezione disponibile per la data selezionata",
+			"errorLoadingClasses": "Impossibile caricare le lezioni. Riprova.",
+			"errorLoadingBookings": "Impossibile caricare le prenotazioni. Riprova.",
 			"tabs": {
 				"classes": "Lezioni",
 				"reservations": "Prenotazioni",

--- a/services/i18n/locales/pt.json
+++ b/services/i18n/locales/pt.json
@@ -99,7 +99,8 @@
 			"availability": "Disponibilidade",
 			"unknown": "Desconhecido",
 			"notes": "Notas",
-			"noClientsFound": "Nenhum cliente encontrado"
+			"noClientsFound": "Nenhum cliente encontrado",
+			"weekdaysShort": ["SEG", "TER", "QUA", "QUI", "SEX", "SÁB", "DOM"]
 		},
 		"enrollClient": {
 			"title": "Inscrever Cliente",
@@ -418,6 +419,9 @@
 			"myBookings": "Minhas Reservas",
 			"noBookings": "Você ainda não tem reservas.",
 			"noClassesBranch": "Nenhuma aula agendada para esta unidade.",
+			"noClassesForDate": "Nenhuma aula disponível para a data selecionada",
+			"errorLoadingClasses": "Não foi possível carregar as aulas. Tente novamente.",
+			"errorLoadingBookings": "Não foi possível carregar suas reservas. Tente novamente.",
 			"tabs": {
 				"classes": "Aulas",
 				"reservations": "Reservas",


### PR DESCRIPTION
THIS PROJECT IS IN MAINTENANCE MODE. We accept pull-requests for Bug Fixes ONLY. NO NEW FEATURES ACCEPTED!

Description
Agregar formato de fechas localizado para tarjetas de clases y calendario
Implementar internacionalización del calendario con traducciones weekdaysShort
Eliminar visualización de capacidad en tarjetas de clases, mostrar solo ocupación
Agregar traducciones i18n faltantes para mensajes de error y estados sin clases
Actualizar WeekCalendar para usar etiquetas de días localizadas
Corregir consistencia de fechas entre calendario y tarjetas de clases
Agregar arrays weekdaysShort para todos los idiomas soportados (ES, FR, DE, IT, PT, EN)

Motivation and Context
Los cambios mejoran la experiencia del usuario en la pantalla de horarios del cliente al:
Mostrar fechas correctamente localizadas en lugar de mostrar siempre "hoy"
Implementar internacionalización completa del calendario
Cambiar la visualización de capacidad por ocupación real de las clases
Corregir inconsistencias en la visualización de fechas entre calendario y tarjetas

How Has This Been Tested?
Verificado que el proyecto compile sin errores
Ejecutado ESLint para asegurar calidad del código
Probado que las traducciones se cargan correctamente
Confirmado que el calendario muestra días de la semana en el idioma correcto
Validado que las tarjetas de clases muestran fechas localizadas correctamente